### PR TITLE
added CoAP vocab, designed after the HTTP RDF vocab

### DIFF
--- a/ontology/coap.ttl
+++ b/ontology/coap.ttl
@@ -1,0 +1,371 @@
+@prefix : <http://www.w3.org/ns/coa#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <http://www.w3.org/ns/coap> .
+
+<http://www.w3.org/ns/coap> rdf:type owl:Ontology ;
+                            
+                            rdfs:label "CoAP in RDF"@en .
+
+
+#################################################################
+#
+#    Object Properties
+#
+#################################################################
+
+
+###  http://www.w3.org/ns/coap#methodCode
+
+:methodCode rdf:type owl:ObjectProperty ;
+            
+            rdfs:range :MethodCode ;
+            
+            rdfs:domain :Request .
+
+
+
+###  http://www.w3.org/ns/coap#options
+
+:options rdf:type owl:ObjectProperty ;
+         
+         rdfs:domain :Message ;
+         
+         rdfs:range :MessageOption .
+
+
+
+###  http://www.w3.org/ns/coap#responseCode
+
+:responseCode rdf:type owl:ObjectProperty ;
+              
+              rdfs:domain :Response ;
+              
+              rdfs:range :ResponseCode .
+
+
+
+
+
+#################################################################
+#
+#    Data properties
+#
+#################################################################
+
+
+###  http://www.w3.org/ns/coap#optionNumber
+
+:optionNumber rdf:type owl:DatatypeProperty ;
+              
+              rdfs:domain :MessageOption .
+
+
+
+###  http://www.w3.org/ns/coap#optionValue
+
+:optionValue rdf:type owl:DatatypeProperty ;
+             
+             rdfs:domain :MessageOption .
+
+
+
+
+
+#################################################################
+#
+#    Classes
+#
+#################################################################
+
+
+###  http://www.w3.org/ns/coap#Code
+
+:Code rdf:type owl:Class .
+
+
+
+###  http://www.w3.org/ns/coap#Message
+
+:Message rdf:type owl:Class .
+
+
+
+###  http://www.w3.org/ns/coap#MessageOption
+
+:MessageOption rdf:type owl:Class .
+
+
+
+###  http://www.w3.org/ns/coap#MethodCode
+
+:MethodCode rdf:type owl:Class ;
+            
+            rdfs:subClassOf :Code .
+
+
+
+###  http://www.w3.org/ns/coap#Request
+
+:Request rdf:type owl:Class ;
+         
+         rdfs:subClassOf :Message .
+
+
+
+###  http://www.w3.org/ns/coap#Response
+
+:Response rdf:type owl:Class ;
+          
+          rdfs:subClassOf :Message .
+
+
+
+###  http://www.w3.org/ns/coap#ResponseCode
+
+:ResponseCode rdf:type owl:Class ;
+              
+              rdfs:subClassOf :Code .
+
+
+
+
+
+#################################################################
+#
+#    Individuals
+#
+#################################################################
+
+
+###  http://www.w3.org/ns/coap#0.01
+
+<http://www.w3.org/ns/coap#0.01> rdf:type owl:NamedIndividual ,
+                                          :MethodCode ;
+                                 
+                                 rdfs:label "GET" .
+
+
+
+###  http://www.w3.org/ns/coap#0.02
+
+<http://www.w3.org/ns/coap#0.02> rdf:type owl:NamedIndividual ,
+                                          :MethodCode ;
+                                 
+                                 rdfs:label "POST" .
+
+
+
+###  http://www.w3.org/ns/coap#0.03
+
+<http://www.w3.org/ns/coap#0.03> rdf:type owl:NamedIndividual ,
+                                          :MethodCode ;
+                                 
+                                 rdfs:label "PUT" .
+
+
+
+###  http://www.w3.org/ns/coap#0.04
+
+<http://www.w3.org/ns/coap#0.04> rdf:type owl:NamedIndividual ,
+                                          :MethodCode ;
+                                 
+                                 rdfs:label "DELETE" .
+
+
+
+###  http://www.w3.org/ns/coap#2.01
+
+<http://www.w3.org/ns/coap#2.01> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Created" .
+
+
+
+###  http://www.w3.org/ns/coap#2.02
+
+<http://www.w3.org/ns/coap#2.02> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Deleted" .
+
+
+
+###  http://www.w3.org/ns/coap#2.03
+
+<http://www.w3.org/ns/coap#2.03> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Valid" .
+
+
+
+###  http://www.w3.org/ns/coap#2.04
+
+<http://www.w3.org/ns/coap#2.04> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Changed" .
+
+
+
+###  http://www.w3.org/ns/coap#2.05
+
+<http://www.w3.org/ns/coap#2.05> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Content" .
+
+
+
+###  http://www.w3.org/ns/coap#4.00
+
+<http://www.w3.org/ns/coap#4.00> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Bad Request" .
+
+
+
+###  http://www.w3.org/ns/coap#4.01
+
+<http://www.w3.org/ns/coap#4.01> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Unauthorized" .
+
+
+
+###  http://www.w3.org/ns/coap#4.02
+
+<http://www.w3.org/ns/coap#4.02> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Bad Option" .
+
+
+
+###  http://www.w3.org/ns/coap#4.03
+
+<http://www.w3.org/ns/coap#4.03> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Forbidden" .
+
+
+
+###  http://www.w3.org/ns/coap#4.04
+
+<http://www.w3.org/ns/coap#4.04> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Not Found" .
+
+
+
+###  http://www.w3.org/ns/coap#4.05
+
+<http://www.w3.org/ns/coap#4.05> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Method Not Allowed" .
+
+
+
+###  http://www.w3.org/ns/coap#4.06
+
+<http://www.w3.org/ns/coap#4.06> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Not Acceptable" .
+
+
+
+###  http://www.w3.org/ns/coap#4.12
+
+<http://www.w3.org/ns/coap#4.12> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Precondition Failed" .
+
+
+
+###  http://www.w3.org/ns/coap#4.13
+
+<http://www.w3.org/ns/coap#4.13> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Request Entity Too Large" .
+
+
+
+###  http://www.w3.org/ns/coap#4.15
+
+<http://www.w3.org/ns/coap#4.15> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Unsupported Content-Format" .
+
+
+
+###  http://www.w3.org/ns/coap#5.00
+
+<http://www.w3.org/ns/coap#5.00> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Internal Server Error" .
+
+
+
+###  http://www.w3.org/ns/coap#5.01
+
+<http://www.w3.org/ns/coap#5.01> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Not Implemented" .
+
+
+
+###  http://www.w3.org/ns/coap#5.02
+
+<http://www.w3.org/ns/coap#5.02> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Bad Gateway" .
+
+
+
+###  http://www.w3.org/ns/coap#5.03
+
+<http://www.w3.org/ns/coap#5.03> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Service Unavailable" .
+
+
+
+###  http://www.w3.org/ns/coap#5.04
+
+<http://www.w3.org/ns/coap#5.04> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Gateway Timeout" .
+
+
+
+###  http://www.w3.org/ns/coap#5.05
+
+<http://www.w3.org/ns/coap#5.05> rdf:type owl:NamedIndividual ,
+                                          :ResponseCode ;
+                                 
+                                 rdfs:label "Proxying Not Supported" .
+
+
+
+
+###  Generated by the OWL API (version 3.5.0) http://owlapi.sourceforge.net
+


### PR DESCRIPTION
Small comment:
the current Binding Template draft defines `coap:optionCode` (Sec. 5.3.2). However, the RFC rather speaks of "Option Number". Shall `coap:optionNumber` be defined instead? It is at least how I defined it in RDF.