### PR TITLE
Use indirect link through references for WebSub and SSE (for issue 68) 

### DIFF
--- a/index.html
+++ b/index.html
@@ -810,7 +810,7 @@
         </section>
 
         <section>
-          <h2>Interaction Verbs</h2>
+          <h2 id="interaction-verbs">Interaction Verbs</h2>
             <p>
               Interactions have one or more defined interaction verbs for each
               interaction pattern. Form Relations allow an interaction to have

--- a/index.html
+++ b/index.html
@@ -690,8 +690,8 @@
           <p>
             Protocols may have defined sub-protocols that can be used for some interaction
             types. For example, to receive asynchronous notifications using http, some
-            servers may support long polling (<code>longpoll</code>), <a href="https://www.w3.org/TR/websub/">WebSub</a> (<code>websub</code>) 
-        and <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events</a> (<code>sse</code>).
+            servers may support long polling (<code>longpoll</code>), WebSub [[websub]] (<code>websub</code>) 
+            and Server-Sent Events [[eventsource]] (<code>sse</code>).
 
             The "subprotocol" item may be defined in a form instance to indicate the
             use of one of these protocols, for example long polling with its special use of HTTP:

--- a/index.html
+++ b/index.html
@@ -810,7 +810,7 @@
         </section>
 
         <section>
-          <h2 id="interaction-verbs">Interaction Verbs</h2>
+          <h2>Interaction Verbs</h2>
             <p>
               Interactions have one or more defined interaction verbs for each
               interaction pattern. Form Relations allow an interaction to have


### PR DESCRIPTION
Currently, links are embedded for WebSub and SSE.

This PR makes proper use of References by using respec constructs [[...]].

(This is for Issue #68)