### PR TITLE
Refining Modbus protocol binding

### DIFF
--- a/index.html
+++ b/index.html
@@ -2119,12 +2119,11 @@
                       {
                           "op": "readproperty",
                           "href": "modbus+tcp://192.168.178.32:502/10003",
-                          "modv:FunctionCodes": "FC2",
-                          "modv:Length": 1,
-                          "modv:Address": "10003",
-                          "modv:UnitID": "1",
-                          "modv:PollingRate": 100,
-                          "contentType": "octet-stream"
+                          "modv:function": "2",
+                          "modv:length": 1,
+                          "modv:offset": "10003",
+                          "modv:unitID": "1",
+                          "contentType": "application/octet-stream"
                       }
                   ]
               },
@@ -2136,12 +2135,11 @@
                       {
                           "op": "readproperty",
                           "href": "modbus+tcp://192.168.178.32:502/10002",
-                          "modv:FunctionCodes": "FC2",
-                          "modv:Length": 1,
-                          "modv:Address": "10002",
-                          "modv:UnitID": "1",
-                          "modv:PollingRate": 100,
-                          "contentType": "octet-stream"
+                          "modv:function": "readDiscreteInput",
+                          "modv:length": 1,
+                          "modv:offset": "10002",
+                          "modv:unitID": "1",
+                          "contentType": "application/octet-stream"
                       }
                   ]
               },
@@ -2153,18 +2151,16 @@
                       {
                           "op": [
                               "writeproperty",
+                              "observeproperty",
                               "readproperty"
                           ],
                           "href": "modbus+tcp://192.168.178.32:502/00006",
-                          "modv:FunctionCodes": [
-                              "FC1",
-                              "FC5"
-                          ],
-                          "modv:Length": 1,
-                          "modv:Address": "00006",
-                          "modv:UnitID": "1",
-                          "modv:PollingRate": 100,
-                          "contentType": "octet-stream"
+                          "modv:entity": "Coil",
+                          "modv:length": 1,
+                          "modv:offset": "00006",
+                          "modv:unitID": "1",
+                          "modv:pollingTime": 100,
+                          "contentType": "application/octet-stream"
                       }
                   ]
               },
@@ -2174,20 +2170,18 @@
                   "description": "Forward Motor Status (single coil). PLC output, can be written to control the motor.",
                   "forms": [
                       {
-                          "op": [
+                           "op": [
                               "writeproperty",
+                              "observeproperty",
                               "readproperty"
                           ],
                           "href": "modbus+tcp://192.168.178.32:502/00003",
-                          "modv:FunctionCodes": [
-                              "FC1",
-                              "FC5"
-                          ],
-                          "modv:Length": 1,
-                          "modv:Address": "00003",
-                          "modv:UnitID": "1",
-                          "modv:PollingRate": 100,
-                          "contentType": "octet-stream"
+                          "modv:entity": "Coil",
+                          "modv:length": 1,,
+                          "modv:offset": "00003",
+                          "modv:unitID": "1",
+                          "modv:pollingRate": 100,
+                          "contentType": "application/octet-stream"
                       }
                   ]
               }

--- a/index.html
+++ b/index.html
@@ -89,6 +89,13 @@
           title: "OCF Specification",
           publisher: "Open Connectivity Foundation",
           date:"Last accessed: February 2020"
+        },
+        "Modbus":{
+          href: "https://modbus.org/specs.php",
+          title: "MODBUS APPLICATION PROTOCOL SPECIFICATION",
+          publisher: "Modbus Organization",
+          status: "",
+          date: "26 April 2012"
         }
       }
     };
@@ -2078,7 +2085,116 @@
           }
         }
       }
-    </pre>  </section>
+    </pre>  
+      </pre>
+
+      <p>
+        Another protocol that can be included in TD this way is Modbus TCP[[?Modbus]]. While Modbus is not a classical IoT protocol, it can nonetheless be described with RDF and utilized in TD as in the following example, which retrofitted an old industrial machine with a PLC.
+      </p>
+      <pre class="example" title="TD of a Thing with Modbus interface">
+        {
+          "@context": [
+              "https://www.w3.org/2019/wot/td/v1",
+              {
+                  "modv": "https://www.example.com/ns/modbustcp"
+              }
+          ],
+          "title": "ModbusPLC",
+          "description": "An industrial machine, retrofitted to be IoT capable.",
+          "id": "uri:dev:ModbusTCPThing",
+          "securityDefinitions": {
+              "nosec_sc": {
+                  "scheme": "nosec"
+              }
+          },
+          "security": "nosec_sc",
+      
+          "base": "",
+          "properties": {
+              "limitSwitch1": {
+                  "title": "downLimitSwitch",
+                  "type": "boolean",
+                  "description": "Limit switch moving downwards",
+                  "forms": [
+                      {
+                          "op": "readproperty",
+                          "href": "modbus+tcp://192.168.178.32:502/10003",
+                          "modv:FunctionCodes": "FC2",
+                          "modv:Length": 1,
+                          "modv:Address": "10003",
+                          "modv:UnitID": "1",
+                          "modv:PollingRate": 100,
+                          "contentType": "octet-stream"
+                      }
+                  ]
+              },
+              "limitSwitch2": {
+                  "title": "forwardLimitSwitch",
+                  "type": "boolean",
+                  "description": "Limit Switch moving forward",
+                  "forms": [
+                      {
+                          "op": "readproperty",
+                          "href": "modbus+tcp://192.168.178.32:502/10002",
+                          "modv:FunctionCodes": "FC2",
+                          "modv:Length": 1,
+                          "modv:Address": "10002",
+                          "modv:UnitID": "1",
+                          "modv:PollingRate": 100,
+                          "contentType": "octet-stream"
+                      }
+                  ]
+              },
+              "moveDown": {
+                  "title": "moveDown",
+                  "type": "boolean",
+                  "description": "Down Motor Status (single coil). PLC output, can be written to control the motor.",
+                  "forms": [
+                      {
+                          "op": [
+                              "writeproperty",
+                              "readproperty"
+                          ],
+                          "href": "modbus+tcp://192.168.178.32:502/00006",
+                          "modv:FunctionCodes": [
+                              "FC1",
+                              "FC5"
+                          ],
+                          "modv:Length": 1,
+                          "modv:Address": "00006",
+                          "modv:UnitID": "1",
+                          "modv:PollingRate": 100,
+                          "contentType": "octet-stream"
+                      }
+                  ]
+              },
+              "moveForward": {
+                  "title": "moveForward",
+                  "type": "boolean",
+                  "description": "Forward Motor Status (single coil). PLC output, can be written to control the motor.",
+                  "forms": [
+                      {
+                          "op": [
+                              "writeproperty",
+                              "readproperty"
+                          ],
+                          "href": "modbus+tcp://192.168.178.32:502/00003",
+                          "modv:FunctionCodes": [
+                              "FC1",
+                              "FC5"
+                          ],
+                          "modv:Length": 1,
+                          "modv:Address": "00003",
+                          "modv:UnitID": "1",
+                          "modv:PollingRate": 100,
+                          "contentType": "octet-stream"
+                      }
+                  ]
+              }
+          }
+      }
+      </pre>
+  </section>
 
 
   <section id="sec-security-considerations">

--- a/ontology/modbus.html
+++ b/ontology/modbus.html
@@ -1,0 +1,64 @@
+
+<!DOCTYPE html>
+<html>
+    <head>
+    <meta charset='utf-8'>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
+    <script class='remove'>
+        var respecConfig = {
+            specStatus: "ED",
+            editors: [],
+            edDraftURI: "https://www.w3.org/2019/wot/modbus",
+            shortName: "wot-binding-templates"
+        };
+    </script>
+    <title>Modbus in RDF</title>
+    </head>
+    <body>
+        <section id='abstract'>
+            <p>Vocabulary to represent Modbus messages in RDF.</p>
+        </section>
+        <section id='sotd'>
+            <p>
+                <em>This document is a work in progress</em>
+            </p>
+        </section>
+        <section>
+            <h2>Introduction</h2>
+
+            <p>
+                To use in TD forms. 
+            </p>
+        </section>
+
+        <section><h2>Axiomatization</h2><section><h3>Classes</h3><section><h4>Code</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#Code</code></p><span>Code</span><table class="def"><tbody><tr><td>Super-class of</td><td><code><a href="#function-code">Function Code</a></code><br><code><a href="#response-code">Response Code</a></code></td></tr></tbody></table></section>
+<section><h4>Function Code</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#FunctionCode</code></p><span>Function Code</span><table class="def"><tbody><tr><td>Sub-class of</td><td><code><a href="#code">Code</a></code></td></tr><tr><td>Enumeration members</td><td><code><a href="#read-single-coils">Read Single Coils</a></code><br><code><a href="#write-multiple-coils">Write Multiple Coils</a></code><br><code><a href="#write-multiple-holding-registers">Write Multiple Holding Registers</a></code><br><code><a href="#read-discrete-inputs">Read Discrete Inputs</a></code><br><code><a href="#read-multiple-holding-registers">Read Multiple Holding Registers</a></code><br><code><a href="#read-multiple-input-registers">Read Multiple Input Registers</a></code><br><code><a href="#read-device-identification">Read Device Identification</a></code><br><code><a href="#write-single-coil">Write Single Coil</a></code></td></tr></tbody></table></section>
+<section><h4>A Modbus Message</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#Message</code></p><span>A Modbus Message</span><table class="def"><tbody><tr><td>Super-class of</td><td><code><a href="#request">Request</a></code><br><code><a href="#response">Response</a></code></td></tr></tbody></table></section>
+<section><h4>Request</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#Request</code></p><span>Request</span><table class="def"><tbody><tr><td>Sub-class of</td><td><code><a href="#a-modbus-message">A Modbus Message</a></code></td></tr></tbody></table></section>
+<section><h4>Response</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#Response</code></p><span>Response</span><table class="def"><tbody><tr><td>Sub-class of</td><td><code><a href="#a-modbus-message">A Modbus Message</a></code></td></tr></tbody></table></section>
+<section><h4>Response Code</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#ResponseCode</code></p><span>Response Code</span><table class="def"><tbody><tr><td>Sub-class of</td><td><code><a href="#code">Code</a></code></td></tr><tr><td>Enumeration members</td><td><code><a href="#illegal-function">ILLEGAL FUNCTION</a></code><br><code><a href="#illegal-data-address">ILLEGAL DATA ADDRESS</a></code><br><code><a href="#illegal-data-value">ILLEGAL DATA VALUE</a></code><br><code><a href="#slavedevice-failure">SLAVEDEVICE FAILURE</a></code><br><code><a href="#acknowledge">ACKNOWLEDGE</a></code><br><code><a href="#slavedevice-buisy">SLAVEDEVICE BUISY</a></code></td></tr></tbody></table></section></section><section><h3>Object Properties</h3><section><h4>Byte Encoding</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#encodingOption</code></p><span>Little Endian or Big Endian encoding of bytes, i.e. the bit order within each register. Default is Big Endian</span><table class="def"><tbody></tbody></table></section>
+<section><h4>First DoubleWord Low Flag</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#firstDWordLow</code></p><span>Data encoding for 64-bit values; same as firstWordLow but based on DWORDS (i.e. 2 registers) instead of WORDS (1 register)</span><table class="def"><tbody></tbody></table></section>
+<section><h4>First Word Low Flag</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#firstWordLow</code></p><span>Data encoding for 32-bit values to chose which of the register is the low value</span><table class="def"><tbody></tbody></table></section>
+<section><h4>Function Code</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#functionCode</code></p><span>Function Code sent by the master in every request. Specifying the desired interaction.</span><table class="def"><tbody></tbody></table></section>
+<section><h4>Length of requested registers/coils</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#length</code></p><span>Specifies the amount of either registers or coils to be read/written</span><table class="def"><tbody></tbody></table></section>
+<section><h4>Request Options</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#options</code></p><span>Request Options</span><table class="def"><tbody></tbody></table></section>
+<section><h4>Modbus TCP maximum polling rate</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#pollingTime</code></p><span>The Modbus specification does not define a maximum or minimum allowed polling rate, however specific implementations might introduce such limits. Defined as integer of milliseconds.</span><table class="def"><tbody></tbody></table></section>
+<section><h4>Response Code</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#responseCode</code></p><span>Response Code returned by the slave after a request</span><table class="def"><tbody></tbody></table></section>
+<section><h4>UnitID</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#unitID</code></p><span>The Unit ID is usually not needed for ModbusTCP, since the IP-address works as unique identifier, but for compability reasons still often included</span><table class="def"><tbody></tbody></table></section>
+<section><h4>Write Value</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#writeValue</code></p><span>The value to write to the register or coil, encoded as integer, omitted and ignored for reading operations</span><table class="def"><tbody></tbody></table></section>
+<section><h4>Zero Based Addressing Flag</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#zeroBasedAddressing</code></p><span>Modbus implementations can differ in the way addressing works, as the first coil/register can be either referred to as '0' or '1'. Default is '0'.</span><table class="def"><tbody></tbody></table></section></section><section><h3>Datatype Properties</h3></section><section><h3>Named Individuals</h3><section><h4>ILLEGAL FUNCTION</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#errorCode#01</code></p><span>Function code received in the query is not recognized or allowed by slave</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#response-code">Response Code</a></code></td></tr></tbody></table></section>
+<section><h4>ILLEGAL DATA ADDRESS</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#errorCode#02</code></p><span>Data address of some or all the required entities are not allowed or do not exist in slave</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#response-code">Response Code</a></code></td></tr></tbody></table></section>
+<section><h4>ILLEGAL DATA VALUE</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#errorCode#03</code></p><span>Value is not accepted by slave</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#response-code">Response Code</a></code></td></tr></tbody></table></section>
+<section><h4>SLAVEDEVICE FAILURE</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#errorCode#04</code></p><span>An unrecoverable error occurred while the slave was attempting to perform the requested action</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#response-code">Response Code</a></code></td></tr></tbody></table></section>
+<section><h4>ACKNOWLEDGE</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#errorCode#05</code></p><span>The server has accepted the request and is processing it, but a long duration of time will be required to do so. This response is returned to prevent a timeout error from occurring in the client. The client can next issue a Poll Program Complete  message to determine if processing is completed</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#response-code">Response Code</a></code></td></tr></tbody></table></section>
+<section><h4>SLAVEDEVICE BUISY</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#errorCode#06</code></p><span>Slave is engaged in processing a long-duration command. Master should retry later </span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#response-code">Response Code</a></code></td></tr></tbody></table></section>
+<section><h4>Read Single Coils</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#functionCode#1</code></p><span>Read a single coil (i.e. boolean/bit access) value. Usually in the address range 00001-09999</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#function-code">Function Code</a></code></td></tr></tbody></table></section>
+<section><h4>Write Multiple Coils</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#functionCode#15</code></p><span>Write Multiple Physical Coils (internal bits). Address range 00001-09999</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#function-code">Function Code</a></code></td></tr></tbody></table></section>
+<section><h4>Write Multiple Holding Registers</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#functionCode#16</code></p><span>Write Multiple Holding Registers (output registers, 16 bit). Address range 40001-49999</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#function-code">Function Code</a></code></td></tr></tbody></table></section>
+<section><h4>Read Discrete Inputs</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#functionCode#2</code></p><span>Read Physical Discrete Inputs (bit access). Address range 10001-19999</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#function-code">Function Code</a></code></td></tr></tbody></table></section>
+<section><h4>Read Multiple Holding Registers</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#functionCode#3</code></p><span>Read Multiple Holding Registers (16 bit access). Address range 40001-49999</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#function-code">Function Code</a></code></td></tr></tbody></table></section>
+<section><h4>Read Multiple Input Registers</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#functionCode#4</code></p><span>Read Multiple Physica Input Registers (16 bits). Address range 30001-39999</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#function-code">Function Code</a></code></td></tr></tbody></table></section>
+<section><h4>Read Device Identification</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#functionCode#43</code></p><span>Read Device Identification for diagnostic purposes. Avaiable in the majority of Modbus implementations</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#function-code">Function Code</a></code></td></tr></tbody></table></section>
+<section><h4>Write Single Coil</h4><p>IRI: <code>https://www.w3.org/2019/wot/modbus#functionCode#5</code></p><span>Write Single Physical Coil (internal bit). Address range 00001-09999</span><table class="def"><tbody><tr><td>Instance of</td><td><code><a href="#function-code">Function Code</a></code></td></tr></tbody></table></section></section></section>
+    </body>
+</html>

--- a/ontology/modbus.ttl
+++ b/ontology/modbus.ttl
@@ -65,7 +65,16 @@ _:jakob a schema:Person ;
 				rdfs:label "Function Code"@en ;
 
 				rdfs:subClassOf :Code, schema:Enumeration .
-	
+
+	:FunctionName rdf:type owl:Class ;
+				rdfs:comment "A Modbus human readable function name"@en ;
+				rdfs:label "Function Name"@en ;
+				rdfs:subClassOf schema:Enumeration .
+
+	:Entity rdf:type owl:Class ;
+				rdfs:comment "A Modbus registry type"@en ;
+				rdfs:label "Entity"@en ;
+				rdfs:subClassOf schema:Enumeration .
 	
 	:ResponseCode rdf:type owl:Class ;
 				  rdfs:comment "Response Code"@en ;
@@ -78,12 +87,19 @@ _:jakob a schema:Person ;
 	
 	# ###  http://www.example.com/ns/modbus#options
 	
-	:functionCode   rdf:type owl:ObjectProperty ;
+	:function   rdf:type owl:ObjectProperty ;
 					rdfs:isDefinedBy <> ;
 					rdfs:comment "Function Code sent by the master in every request. Specifying the desired interaction."@en ;
-					rdfs:label "Function Code"@en ;
+					rdfs:label "Function"@en ;
 					rdfs:domain :Request ;
-					rdfs:range :FunctionCode .
+					rdfs:range :FunctionCode, :FunctionName .
+
+	:entity   rdf:type owl:ObjectProperty ;
+					rdfs:isDefinedBy <> ;
+					rdfs:comment "A registry type to let the runtime automatically detect the right function code"@en ;
+					rdfs:label "Entity"@en ;
+					rdfs:domain :Request ;
+					rdfs:range :Entity .
 	
 	
 	:responseCode rdf:type owl:ObjectProperty ;
@@ -151,6 +167,16 @@ _:jakob a schema:Person ;
 						 rdf:range xsd:integer ;
 						 rdfs:domain :RequestOption;
 						 om:usesUnit om:milliseconds.
+
+	:functionName		 rdf:type owl:ObjectProperty;
+						 rdfs:label "Function name of a function Code"@en;
+						 rdf:range :FunctionName ;
+						 rdfs:domain :FunctionCode.
+
+	:functionCode		 rdf:type owl:ObjectProperty;
+						 rdfs:label "Function code of a function Name"@en;
+						 rdf:range :FunctionCode ;
+						 rdfs:domain :FunctionName.
 	
 	#################################################################
 	#
@@ -163,44 +189,127 @@ _:jakob a schema:Person ;
 	<functionCode#1>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:label  "Read Single Coils"@en;
-			rdfs:comment  "Read a single coil (i.e. boolean/bit access) value. Usually in the address range 00001-09999"@en.
+			rdfs:comment  "Read a single coil (i.e. boolean/bit access) value. Usually in the address range 00001-09999"@en;
+			:functionName <#readCoil>.
 	
 	<functionCode#2>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:comment  "Read Physical Discrete Inputs (bit access). Address range 10001-19999"@en;
-			rdfs:label  "Read Discrete Inputs"@en.
+			rdfs:label  "Read Discrete Inputs"@en;
+			:functionName <#readDiscreteInput>.
 	
 	<functionCode#3>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:label  "Read Multiple Holding Registers"@en ;
-			rdfs:comment  "Read Multiple Holding Registers (16 bit access). Address range 40001-49999"@en.
+			rdfs:comment  "Read Multiple Holding Registers (16 bit access). Address range 40001-49999"@en;
+			:functionName <#readHoldingRegisters>.
 	
 	<functionCode#4>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:label  "Read Multiple Input Registers" @en;
-			rdfs:comment  "Read Multiple Physica Input Registers (16 bits). Address range 30001-39999"@en.
+			rdfs:comment  "Read Multiple Physica Input Registers (16 bits). Address range 30001-39999"@en;
+			:functionName <#readInputRegisters>.
 	
 	<functionCode#5>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:label  "Write Single Coil"@en ;
-			rdfs:comment  "Write Single Physical Coil (internal bit). Address range 00001-09999"@en.
+			rdfs:comment  "Write Single Physical Coil (internal bit). Address range 00001-09999"@en;
+			:functionName <#writeSingleCoil>.
 	
+	<functionCode#6>    rdf:type    owl:NamedIndividual ,
+						:FunctionCode ;
+			rdfs:label  "Write Single HoldingRegister"@en ;
+			rdfs:comment  "Write Single HoldingRegister (internal bits). Address range 40001-49999"@en;
+			:functionName <#writeSingleHoldingRegister>.
+
 	<functionCode#15>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:label  "Write Multiple Coils"@en ;
-			rdfs:comment  "Write Multiple Physical Coils (internal bits). Address range 00001-09999"@en.
-	
+			rdfs:comment  "Write Multiple Physical Coils (internal bits). Address range 00001-09999"@en;
+			:functionName <#writeMultipleCoils>.
+
 	<functionCode#16>   rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:label  "Write Multiple Holding Registers"@en ;
-			rdfs:comment  "Write Multiple Holding Registers (output registers, 16 bit). Address range 40001-49999"@en.
+			rdfs:comment  "Write Multiple Holding Registers (output registers, 16 bit). Address range 40001-49999"@en;
+			:functionName <#writeMultipleHoldingRegisters>.
+
 	
 	<functionCode#43>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:comment  "Read Device Identification for diagnostic purposes. Avaiable in the majority of Modbus implementations"@en ;
 			rdfs:label  "Read Device Identification"@en.
 	
+	### Modbus Function names
+
+	<#readCoil>    rdf:type    owl:NamedIndividual ,
+						:FunctionName ;
+			rdfs:label  "Read Single Coils"@en;
+			rdfs:comment  "Read a single coil (i.e. boolean/bit access) value. Usually in the address range 00001-09999"@en;
+			:functionCode <functionCode#1>.
 	
+	<#readDiscreteInput>    rdf:type    owl:NamedIndividual ,
+						:FunctionName ;
+			rdfs:comment  "Read Physical Discrete Inputs (bit access). Address range 10001-19999"@en;
+			rdfs:label  "Read Discrete Inputs"@en;
+			:functionCode <functionCode#2>.
+	
+	<#readHoldingRegisters>    rdf:type    owl:NamedIndividual ,
+						:FunctionName ;
+			rdfs:label  "Read Multiple Holding Registers"@en ;
+			rdfs:comment  "Read Multiple Holding Registers (16 bit access). Address range 40001-49999"@en;
+			:functionCode <functionCode#3>.
+
+	<#readInputRegisters>    rdf:type    owl:NamedIndividual ,
+						:FunctionName ;
+			rdfs:label  "Read Multiple Input Registers" @en;
+			rdfs:comment  "Read Multiple Physical Input Registers (16 bits). Address range 30001-39999"@en;
+			:functionCode <functionCode#4>.
+	
+	<#writeSingleCoil>    rdf:type    owl:NamedIndividual ,
+						:FunctionName ;
+			rdfs:label  "Write Single Coil"@en ;
+			rdfs:comment  "Write Single Physical Coil (internal bit). Address range 00001-09999"@en;
+			:functionCode <functionCode#5>.
+
+	<#writeSingleHoldingRegister>    rdf:type    owl:NamedIndividual ,
+						:FunctionName ;
+			rdfs:label  "Write Single HoldingRegister"@en ;
+			rdfs:comment  "Write Single HoldingRegister (internal bits). Address range 40001-49999"@en;
+			:functionCode <functionCode#6>.
+
+	<#writeMultipleCoils>    rdf:type    owl:NamedIndividual ,
+						:FunctionName ;
+			rdfs:label  "Write Multiple Coils"@en ;
+			rdfs:comment  "Write Multiple Physical Coils (internal bits). Address range 00001-09999"@en;
+			:functionCode <functionCode#15>.
+
+	<#writeMultipleHoldingRegisters>   rdf:type    owl:NamedIndividual ,
+						:FunctionName ;
+			rdfs:label  "Write Multiple Holding Registers"@en ;
+			rdfs:comment  "Write Multiple Holding Registers (output registers, 16 bit). Address range 40001-49999"@en;
+			:functionCode <functionCode#16>.
+
+	### Modbus Entities
+	<#Coil>   rdf:type    owl:NamedIndividual ,
+						:Entity ;
+			rdfs:label  "Coil"@en ;
+			rdfs:comment  "Represent a modbus coil register.  These entities can be read or written"@en.
+
+	<#DiscreteInput>   rdf:type    owl:NamedIndividual ,
+						:Entity ;
+			rdfs:label  "Discrete Input"@en ;
+			rdfs:comment  "Represent a modbus discrete input. These entities can only be read"@en.
+	<#InputRegister>   rdf:type    owl:NamedIndividual ,
+						:Entity ;
+			rdfs:label  "Input Register"@en ;
+			rdfs:comment  "Represent a modbus input register. These entities can only be read"@en.
+	<#HoldingRegister>   rdf:type    owl:NamedIndividual ,
+						:Entity ;
+			rdfs:label  "Holding Register"@en ;
+			rdfs:comment  "Represent a modbus holding register.  These entities can be read or written"@en.
+
+
 	### Modbus responses
 	
 	###  http://www.example.com/ns/modbus#2.01

--- a/ontology/modbus.ttl
+++ b/ontology/modbus.ttl
@@ -160,42 +160,42 @@ _:jakob a schema:Person ;
 	
 	
 	###  http://www.example.com/ns/modbus#FC1 == :FC1
-	<#functionCode#1>    rdf:type    owl:NamedIndividual ,
+	<functionCode#1>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:label  "Read Single Coils"@en;
 			rdfs:comment  "Read a single coil (i.e. boolean/bit access) value. Usually in the address range 00001-09999"@en.
 	
-	<#functionCode#2>    rdf:type    owl:NamedIndividual ,
+	<functionCode#2>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:comment  "Read Physical Discrete Inputs (bit access). Address range 10001-19999"@en;
 			rdfs:label  "Read Discrete Inputs"@en.
 	
-	<#functionCode#3>    rdf:type    owl:NamedIndividual ,
+	<functionCode#3>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:label  "Read Multiple Holding Registers"@en ;
 			rdfs:comment  "Read Multiple Holding Registers (16 bit access). Address range 40001-49999"@en.
 	
-	<#functionCode#4>    rdf:type    owl:NamedIndividual ,
+	<functionCode#4>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:label  "Read Multiple Input Registers" @en;
 			rdfs:comment  "Read Multiple Physica Input Registers (16 bits). Address range 30001-39999"@en.
 	
-	<#functionCode#5>    rdf:type    owl:NamedIndividual ,
+	<functionCode#5>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:label  "Write Single Coil"@en ;
 			rdfs:comment  "Write Single Physical Coil (internal bit). Address range 00001-09999"@en.
 	
-	<#functionCode#15>    rdf:type    owl:NamedIndividual ,
+	<functionCode#15>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:label  "Write Multiple Coils"@en ;
 			rdfs:comment  "Write Multiple Physical Coils (internal bits). Address range 00001-09999"@en.
 	
-	<#functionCode#16>   rdf:type    owl:NamedIndividual ,
+	<functionCode#16>   rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:label  "Write Multiple Holding Registers"@en ;
 			rdfs:comment  "Write Multiple Holding Registers (output registers, 16 bit). Address range 40001-49999"@en.
 	
-	<#functionCode#43>    rdf:type    owl:NamedIndividual ,
+	<functionCode#43>    rdf:type    owl:NamedIndividual ,
 						:FunctionCode ;
 			rdfs:comment  "Read Device Identification for diagnostic purposes. Avaiable in the majority of Modbus implementations"@en ;
 			rdfs:label  "Read Device Identification"@en.
@@ -205,32 +205,32 @@ _:jakob a schema:Person ;
 	
 	###  http://www.example.com/ns/modbus#2.01
 	
-	<#errorCode#01>   rdf:type    owl:NamedIndividual ,
+	<errorCode#01>   rdf:type    owl:NamedIndividual ,
 						:ResponseCode ;                         
 			rdfs:comment "Function code received in the query is not recognized or allowed by slave"@en;
 			rdfs:label "ILLEGAL FUNCTION"@en .
 	
-	<#errorCode#02>   rdf:type    owl:NamedIndividual ,
+	<errorCode#02>   rdf:type    owl:NamedIndividual ,
 						:ResponseCode ;                         
 			rdfs:comment "Data address of some or all the required entities are not allowed or do not exist in slave"@en ;
 			rdfs:label "ILLEGAL DATA ADDRESS"@en .
 	
-	<#errorCode#03>   rdf:type    owl:NamedIndividual ,
+	<errorCode#03>   rdf:type    owl:NamedIndividual ,
 						:ResponseCode ;                         
 			rdfs:comment "Value is not accepted by slave"@en ;
 			rdfs:label "ILLEGAL DATA VALUE"@en .
 	
-	<#errorCode#04>   rdf:type    owl:NamedIndividual ,
+	<errorCode#04>   rdf:type    owl:NamedIndividual ,
 						:ResponseCode ;                         
 			rdfs:label "SLAVEDEVICE FAILURE" ;
 			rdfs:comment "An unrecoverable error occurred while the slave was attempting to perform the requested action"@en .
 			
-	<#errorCode#05>   rdf:type    owl:NamedIndividual ,
+	<errorCode#05>   rdf:type    owl:NamedIndividual ,
 						:ResponseCode ;
 			rdfs:label  "ACKNOWLEDGE" ;
 			rdfs:comment "The server has accepted the request and is processing it, but a long duration of time will be required to do so. This response is returned to prevent a timeout error from occurring in the client. The client can next issue a Poll Program Complete  message to determine if processing is completed"@en.
 	
-	<#errorCode#06>   rdf:type    owl:NamedIndividual ,
+	<errorCode#06>   rdf:type    owl:NamedIndividual ,
 						:ResponseCode ;                         
 			rdfs:comment "Slave is engaged in processing a long-duration command. Master should retry later "@en ;
 			rdfs:label "SLAVEDEVICE BUISY"@en .

--- a/ontology/modbus.ttl
+++ b/ontology/modbus.ttl
@@ -124,6 +124,12 @@ _:jakob a schema:Person ;
 			rdfs:label "Length of requested registers/coils"@en ;
 			rdf:range xsd:integer ;
 			rdfs:domain :RequestOption .
+
+	:offset rdf:type owl:ObjectProperty ;
+			rdfs:comment "Specifies the starting address of the modbus operations"@en ;
+			rdfs:label "Offset"@en ;
+			rdf:range xsd:integer ;
+			rdfs:domain :RequestOption .
 	
 	:unitID rdf:type owl:ObjectProperty;
 			rdfs:label "UnitID"@en ;

--- a/ontology/modbus.ttl
+++ b/ontology/modbus.ttl
@@ -1,0 +1,236 @@
+@prefix : <https://www.w3.org/2019/wot/modbus#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@base <https://www.w3.org/2019/wot/modbus> .
+
+@prefix om: <http://www.ontology-of-units-of-measure.org/resource/om-2/>.
+	
+
+
+<> 	rdf:type owl:Ontology ;					
+	rdfs:label "Modbus in RDF"@en;
+	rdfs:comment "Vocabulary to represent Modbus messages in RDF."@en ;
+	vann:preferredNamespacePrefix "modv" ;
+   	vann:preferredNamespaceUri : ;
+	dct:author _:jakob;
+	dct:contributor _:jakob .
+
+_:jakob a schema:Person ;
+	schema:name "Jakob Müller" .
+
+	
+	
+	
+	 
+	### Classes
+	
+	###  http://www.example.com/ns/modbus#Message
+	
+	:Message rdf:type owl:Class;
+	    	rdfs:isDefinedBy <> ;
+        	rdfs:comment "A Modbus Message"@en ;
+			rdfs:label "A Modbus Message"@en.
+	
+	
+	###  http://www.example.com/ns/modbus#Request
+	
+	:Request rdf:type owl:Class ;
+			 rdfs:comment "Request"@en ;
+ 			 rdfs:label "Request"@en ;
+
+			 rdfs:subClassOf :Message .
+	
+	###  http://www.example.com/ns/modbus#Response
+	
+	:Response rdf:type owl:Class ;
+				rdfs:comment "Response"@en ;
+				rdfs:label "Response"@en ;
+
+			  rdfs:subClassOf :Message .
+	
+	
+	###  http://www.example.com/ns/modbus#Code
+	
+	:Code rdf:type owl:Class;
+					rdfs:comment "Code"@en .
+	
+	:FunctionCode rdf:type owl:Class ;
+				rdfs:comment "Function Code"@en ;
+				rdfs:label "Function Code"@en ;
+
+				rdfs:subClassOf :Code, schema:Enumeration .
+	
+	
+	:ResponseCode rdf:type owl:Class ;
+				  rdfs:comment "Response Code"@en ;
+				  rdfs:label "Response Code"@en ;
+
+				  rdfs:subClassOf :Code, schema:Enumeration  .
+	
+	
+	### Properties
+	
+	# ###  http://www.example.com/ns/modbus#options
+	
+	:functionCode   rdf:type owl:ObjectProperty ;
+					rdfs:isDefinedBy <> ;
+					rdfs:comment "Function Code sent by the master in every request. Specifying the desired interaction."@en ;
+					rdfs:label "Function Code"@en ;
+					rdfs:domain :Request ;
+					rdfs:range :FunctionCode .
+	
+	
+	:responseCode rdf:type owl:ObjectProperty ;
+				  rdfs:comment "Response Code returned by the slave after a request"@en ;
+				  rdfs:label "Response Code"@en ;
+				  rdfs:isDefinedBy <> ;
+				  rdfs:domain :Response ;			  
+				  rdfs:range :ResponseCode .
+	
+	
+	:options    rdf:type owl:ObjectProperty ;
+				rdfs:comment "Request Options"@en ;
+				rdfs:label "Request Options"@en ;
+	
+				rdfs:domain :Request ;
+				rdfs:range :RequestOption .
+	
+	
+	
+	:length rdf:type owl:ObjectProperty ;
+			rdfs:comment "Specifies the amount of either registers or coils to be read/written"@en ;
+			rdfs:label "Length of requested registers/coils"@en ;
+			rdf:range xsd:integer ;
+			rdfs:domain :RequestOption .
+	
+	:unitID rdf:type owl:ObjectProperty;
+			rdfs:label "UnitID"@en ;
+			rdfs:comment "The Unit ID is usually not needed for ModbusTCP, since the IP-address works as unique identifier, but for compability reasons still often included";
+			rdf:range xsd:integer ;
+			rdfs:domain :RequestOption .
+	
+	:writeValue rdf:type owl:ObjectProperty;
+			rdfs:label "Write Value"@en ;
+			rdfs:comment "The value to write to the register or coil, encoded as integer, omitted and ignored for reading operations"@en ;
+			rdf:range xsd:integer ;
+			rdfs:domain :RequestOption .
+	
+	:encodingOption rdf:type owl:ObjectProperty;
+					rdf:type xsd:string ;
+					rdfs:domain :RequestOption;
+					rdfs:label "Byte Encoding"@en;
+					rdfs:comment "Little Endian or Big Endian encoding of bytes, i.e. the bit order within each register. Default is Big Endian"@en.
+	
+	:firstWordLow rdf:type owl:ObjectProperty;
+				  rdf:range xsd:boolean ;
+				  rdfs:domain :RequestOption ;
+				  rdfs:label "First Word Low Flag"@en;
+				  rdfs:comment "Data encoding for 32-bit values to chose which of the register is the low value"@en.
+	
+	:firstDWordLow  rdf:type owl:ObjectProperty;
+					rdf:range xsd:boolean ;
+					rdfs:domain :RequestOption ;
+					rdfs:label "First DoubleWord Low Flag"@en;
+					rdfs:comment "Data encoding for 64-bit values; same as firstWordLow but based on DWORDS (i.e. 2 registers) instead of WORDS (1 register)"@en.
+	
+	:zeroBasedAddressing rdf:type owl:ObjectProperty;
+						 rdfs:label "Zero Based Addressing Flag"@en;
+						 rdfs:comment "Modbus implementations can differ in the way addressing works, as the first coil/register can be either referred to as '0' or '1'. Default is '0'."@en;
+						 rdf:range xsd:boolean ;
+						 rdfs:domain :RequestOption .
+	
+	:pollingTime         rdf:type owl:ObjectProperty;
+						 rdfs:label "Modbus TCP maximum polling rate"@en;
+						 rdfs:comment "The Modbus specification does not define a maximum or minimum allowed polling rate, however specific implementations might introduce such limits. Defined as integer of milliseconds.";
+						 rdf:range xsd:integer ;
+						 rdfs:domain :RequestOption;
+						 om:usesUnit om:milliseconds.
+	
+	#################################################################
+	#
+	#    Individuals
+	#
+	#################################################################
+	
+	
+	###  http://www.example.com/ns/modbus#FC1 == :FC1
+	<#functionCode#1>    rdf:type    owl:NamedIndividual ,
+						:FunctionCode ;
+			rdfs:label  "Read Single Coils"@en;
+			rdfs:comment  "Read a single coil (i.e. boolean/bit access) value. Usually in the address range 00001-09999"@en.
+	
+	<#functionCode#2>    rdf:type    owl:NamedIndividual ,
+						:FunctionCode ;
+			rdfs:comment  "Read Physical Discrete Inputs (bit access). Address range 10001-19999"@en;
+			rdfs:label  "Read Discrete Inputs"@en.
+	
+	<#functionCode#3>    rdf:type    owl:NamedIndividual ,
+						:FunctionCode ;
+			rdfs:label  "Read Multiple Holding Registers"@en ;
+			rdfs:comment  "Read Multiple Holding Registers (16 bit access). Address range 40001-49999"@en.
+	
+	<#functionCode#4>    rdf:type    owl:NamedIndividual ,
+						:FunctionCode ;
+			rdfs:label  "Read Multiple Input Registers" @en;
+			rdfs:comment  "Read Multiple Physica Input Registers (16 bits). Address range 30001-39999"@en.
+	
+	<#functionCode#5>    rdf:type    owl:NamedIndividual ,
+						:FunctionCode ;
+			rdfs:label  "Write Single Coil"@en ;
+			rdfs:comment  "Write Single Physical Coil (internal bit). Address range 00001-09999"@en.
+	
+	<#functionCode#15>    rdf:type    owl:NamedIndividual ,
+						:FunctionCode ;
+			rdfs:label  "Write Multiple Coils"@en ;
+			rdfs:comment  "Write Multiple Physical Coils (internal bits). Address range 00001-09999"@en.
+	
+	<#functionCode#16>   rdf:type    owl:NamedIndividual ,
+						:FunctionCode ;
+			rdfs:label  "Write Multiple Holding Registers"@en ;
+			rdfs:comment  "Write Multiple Holding Registers (output registers, 16 bit). Address range 40001-49999"@en.
+	
+	<#functionCode#43>    rdf:type    owl:NamedIndividual ,
+						:FunctionCode ;
+			rdfs:comment  "Read Device Identification for diagnostic purposes. Avaiable in the majority of Modbus implementations"@en ;
+			rdfs:label  "Read Device Identification"@en.
+	
+	
+	### Modbus responses
+	
+	###  http://www.example.com/ns/modbus#2.01
+	
+	<#errorCode#01>   rdf:type    owl:NamedIndividual ,
+						:ResponseCode ;                         
+			rdfs:comment "Function code received in the query is not recognized or allowed by slave"@en;
+			rdfs:label "ILLEGAL FUNCTION"@en .
+	
+	<#errorCode#02>   rdf:type    owl:NamedIndividual ,
+						:ResponseCode ;                         
+			rdfs:comment "Data address of some or all the required entities are not allowed or do not exist in slave"@en ;
+			rdfs:label "ILLEGAL DATA ADDRESS"@en .
+	
+	<#errorCode#03>   rdf:type    owl:NamedIndividual ,
+						:ResponseCode ;                         
+			rdfs:comment "Value is not accepted by slave"@en ;
+			rdfs:label "ILLEGAL DATA VALUE"@en .
+	
+	<#errorCode#04>   rdf:type    owl:NamedIndividual ,
+						:ResponseCode ;                         
+			rdfs:label "SLAVEDEVICE FAILURE" ;
+			rdfs:comment "An unrecoverable error occurred while the slave was attempting to perform the requested action"@en .
+			
+	<#errorCode#05>   rdf:type    owl:NamedIndividual ,
+						:ResponseCode ;
+			rdfs:label  "ACKNOWLEDGE" ;
+			rdfs:comment "The server has accepted the request and is processing it, but a long duration of time will be required to do so. This response is returned to prevent a timeout error from occurring in the client. The client can next issue a Poll Program Complete  message to determine if processing is completed"@en.
+	
+	<#errorCode#06>   rdf:type    owl:NamedIndividual ,
+						:ResponseCode ;                         
+			rdfs:comment "Slave is engaged in processing a long-duration command. Master should retry later "@en ;
+			rdfs:label "SLAVEDEVICE BUISY"@en .

--- a/ontology/modbus.ttl
+++ b/ontology/modbus.ttl
@@ -167,6 +167,13 @@ _:jakob a schema:Person ;
 						 rdf:range xsd:integer ;
 						 rdfs:domain :RequestOption;
 						 om:usesUnit om:milliseconds.
+	
+	:timeout         rdf:type owl:ObjectProperty;
+						 rdfs:label "Modbus response maximum waiting time"@en;
+						 rdfs:comment "Defines how much time the runtime should wait until it receives a reply from the device.";
+						 rdf:range xsd:integer ;
+						 rdfs:domain :RequestOption;
+						 om:usesUnit om:milliseconds.
 
 	:functionName		 rdf:type owl:ObjectProperty;
 						 rdfs:label "Function name of a function Code"@en;

--- a/render.js
+++ b/render.js
@@ -17,7 +17,8 @@ sttl.connect(q => {
 
 const src = [
     'ontology/coap.ttl',
-    'ontology/mqtt.ttl'
+    'ontology/mqtt.ttl',
+    'ontology/modbus.ttl'
 ];
 
 src.reduce((p, f) => {


### PR DESCRIPTION
This PR is based on the work of #98 and it focuses on the vocabulary alignment with the current [node-wot modbus implementation](https://github.com/eclipse/thingweb.node-wot/tree/3e9ccd44072a097d0452b5c306819c6d8fb04e12/packages/binding-modbus) (see also https://github.com/eclipse/thingweb.node-wot/issues/297). It fixes also the main example provided in the index.html. 

Known open issues:
- The implementation uses [range](https://github.com/eclipse/thingweb.node-wot/tree/3e9ccd44072a097d0452b5c306819c6d8fb04e12/packages/binding-modbus#modbusrange) to specify the starting and the end of the reading/writing operation. The vocabulary uses `offset` and `length`
- This proposal does not follow the new guidelines for a protocol binding description 