### PR TITLE
Well-know Media Types content paremeters

### DIFF
--- a/index.html
+++ b/index.html
@@ -745,6 +745,35 @@
                             <li><code>application/octet-stream</code>: Generic binary stream</li>
                         </ul>
                     </ul>
+
+                    <section>
+                        <h4>Wellknown Media Types parameters</h4>
+                        <p>
+                            Other than a type and subtype, Media Types might contain parameters [[IANA-MEDIA-TYPES]]. These parameters are
+                            specified in the form of a key value pair separated by an equal sign (e.g.
+                            <code>text/html;charset=utf-8</code>).
+                            This section describes a set of wellknown parameters in the context of the Web of Things.
+                        </p>
+                        <ul>
+                            <li>
+                                <b>byteSeq</b>: The byte sequence parameter indicates the endianness of the raw payload with media type
+                                <code>application/octet-stream</code>. The accepted values are <code>BIG_ENDIAN</code> (default value),
+                                <code>LITTLE_ENDIAN</code>, <code>BIG_ENDIAN_BYTE_SWAP</code>, and <code>LITTLE_ENDIAN_BYTE_SWAP</code>.
+                                The <b>byteSeq</b> parameter is useful in protocols that does not have a native endianness definition
+                                and different nodes adopt one or another depending on the host platform.
+                            </li>
+                        </ul>
+                        <pre class="example" title="byteSeq parameter in forms" id="example-byteseq-parameter">
+                            {
+                                "forms":[{
+                                    "href": "modbus+tcp://127.0.0.1:60000/1",
+                                    "modbus:function": "readCoil",
+                                    "op": "readproperty",
+                                    "contentType": "application/octet-stream;byteSeq=LITTLE_ENDIAN"
+                                }]
+                            }
+                        </pre>
+                    </section>
                 </section>
                 <section id="payload-bindings-dataschema">
                     <h5>Data Schemas</h5>


### PR DESCRIPTION
In implementing the MODBUS protocol binding for node-wot, we found the need to define a Media Type parameter for indicating the endianness of a payload encoded with application/octet-stream. Since the parameter might also be used in other protocols, this PR updates the main document with a section dedicated to a set of well-known parameters used in WoT. 

Consider it as a first draft of the section as I would like to discuss our options to describe these parameters.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/relu91/wot-binding-templates/pull/161.html" title="Last updated on Apr 12, 2023, 8:24 AM UTC (15581a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/161/160d01d...relu91:15581a1.html" title="Last updated on Apr 12, 2023, 8:24 AM UTC (15581a1)">Diff</a>