### PR TITLE
feat(modbus): move addres and quantity to URL components

### DIFF
--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -70,7 +70,7 @@
         Considering that in Web of Things context all protocol bindings are required to at least support the Internet Protocol, for the Modbus protocol <code>modbus+tcp://</code> 
         was selected as the only valid URL scheme. The following shows the typical structure of an URL of the Modbus protocol:
         <pre>
-            modbus+tcp://{address}:{port}/{?unitID}
+            modbus+tcp://{address}:{port}/{unitID}/{address}?quantity={?quantity}
         </pre>
 
         <p>
@@ -79,13 +79,62 @@
                 <li><code>{address}</code> is the IP address of the Modbus device</li>
                 <li><code>{port}</code> is the port of the Modbus device</li>
                 <li><code>{unitID}</code> is the unit ID of the Modbus device. See <a href="#vocabulary">vocabulary</a></li>
+                <li><code>{address}</code> is the address of the register/coil referenced in this URL. See <a href="#vocabulary">vocabulary</a></li>
+                <li><code>{quantity}</code> the amount of registers/coils referenced in this URL. See <a href="#vocabulary">vocabulary</a></li>
             </ul>
+            For the full syntax see [[[#abnf]]]
         </p>
     </section>
     <section id="vocabulary">
         <h2>Modbus Vocabulary</h2>
         This section describes the vocabulary used in the Modbus protocol. A protocol binding implementation should use the vocabulary defined in this section to
         describe the different configuration that can be used to exchanged data between Web of Things.
+        <section>
+            <h3>URL terms</h3>
+            <table class="def">
+                <thead>
+                    <tr>
+                        <th>Vocabulary term</th>
+                        <th>Description</th>
+                        <th>Assignment</th>
+                        <th>Type</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- Generate forms terms from the ontology-->
+                    
+        
+        <tr>
+            <td><code>modbus:address</code></td>
+            <td>Specifies the starting address of the Modbus operations</td>
+            <td>required</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#integer">integer</a></td>
+
+        <tr>
+        
+
+        
+        <tr>
+            <td><code>modbus:unitID</code></td>
+            <td>The Unit ID is usually not needed for ModbusTCP, since the IP-address works as unique identifier, but for compability reasons still often included</td>
+            <td>required</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#integer">integer</a></td>
+
+        <tr>
+        
+
+        
+        <tr>
+            <td><code>modbus:quantity</code></td>
+            <td>Specifies the amount of either registers or coils to be read or written to</td>
+            <td>optional</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#integer">integer</a></td>
+
+        <tr>
+        
+                </tbody>
+            </table>
+        </section>
         <section>
             <h3>Form terms</h3>
             <table class="def">
@@ -100,33 +149,6 @@
                 <tbody>
                     <!-- Generate forms terms from the ontology-->
                     
-        <tr>
-            <td><code>modbus:address</code></td>
-            <td>Specifies the starting address of the Modbus operations</td>
-            <td>required</td>
-            <td><a href="http://www.w3.org/2001/XMLSchema#integer">integer</a></td>
-
-        <tr>
-        
-
-        <tr>
-            <td><code>modbus:unitID</code></td>
-            <td>The Unit ID is usually not needed for ModbusTCP, since the IP-address works as unique identifier, but for compability reasons still often included</td>
-            <td>required</td>
-            <td><a href="http://www.w3.org/2001/XMLSchema#integer">integer</a></td>
-
-        <tr>
-        
-
-        <tr>
-            <td><code>modbus:quantity</code></td>
-            <td>Specifies the amount of either registers or coils to be read or written to</td>
-            <td>optional</td>
-            <td><a href="http://www.w3.org/2001/XMLSchema#integer">integer</a></td>
-
-        <tr>
-        
-
         <tr>
             <td><code>modbus:pollingTime</code></td>
             <td>Modbus TCP maximum polling rate. The Modbus specification does not define a maximum or minimum allowed polling rate, however specific implementations might introduce such limits. Defined as integer of milliseconds.</td>
@@ -468,32 +490,29 @@
         a short description of the modbus endpoint.
         <pre id="example-read-coil-entity" class="example" title="Read and write single coil">
                     {
-                        "href": "modbus+tcp://127.0.0.1:60000/1",
+                        "href": "modbus+tcp://127.0.0.1:60000/1/1",
                         "op": [
                             "readproperty",
                             "writeproperty"
                         ],
                         "modbus:entity": "Coil",
-                        "modbus:address": 1
                     }
         </pre>
         A TD processor will intepred [[[#example-read-coil-entity]]] configuration as the following:
         <pre id="example-read-coil-entity" class="example" title="Read and write single coil expanded">
                             {
-                                "href": "modbus+tcp://127.0.0.1:60000/1",
+                                "href": "modbus+tcp://127.0.0.1:60000/1/1",
                                 "op": [
                                     "readproperty",
                                 ],
                                 "modbus:function": "readCoil",
-                                "modbus:address": 1
                             },
                             {
-                                "href": "modbus+tcp://127.0.0.1:60000/1",
+                                "href": "modbus+tcp://127.0.0.1:60000/1/1",
                                 "op": [
                                     "writeproperty",
                                 ],
                                 "modbus:function": "writeCoil",
-                                "modbus:address": 1
                             },
         </pre>
         Reducing effectively the verbosity of a TD. 
@@ -503,14 +522,12 @@
         8 HoldingRegisters. 
         <pre id="example-read-holding" class="example" title="Read 8 holding registers">
                             {
-                                "href": "modbus+tcp://127.0.0.1:60000/1",
+                                "href": "modbus+tcp://127.0.0.1:60000/1/40001?quantity=8",
                                 "op": [
                                     "readproperty",
                                     "writeproperty"
                                 ],
-                                "modbus:entity": "HoldingRegister",
-                                "modbus:address": 40001,
-                                "modbus:quantity": 8
+                                "modbus:entity": "HoldingRegister"
                             }
                 </pre>
         When possible WoT consumers will use Modbus features to read the desired amount of data with a single
@@ -519,14 +536,12 @@
         In these circumstances consumers will perform different requests to satisfy the configuration requirements. 
         <pre id="example-read-coil-range" class="example" title="Read and write 8 single coils with one form">
                             {
-                                "href": "modbus+tcp://127.0.0.1:60000/1",
+                                "href": "modbus+tcp://127.0.0.1:60000/1/1?quantity=8",
                                 "op": [
                                     "readproperty",
                                     "writeproperty"
                                 ],
-                                "modbus:entity": "Coil",
-                                "modbus:address": 1,
-                                "modbus:quantity": 8
+                                "modbus:entity": "Coil"
                             }
                 </pre>
         Another notable configuration of a form using the Modbus vocabulary is the polling mechanism. Thanks
@@ -537,13 +552,12 @@
         default for observing a property. 
         <pre  id="example-polling" class="example" title="Polling">
             {
-                "href": "modbus+tcp://127.0.0.1:60000/1",
+                "href": "modbus+tcp://127.0.0.1:60000/1/1",
                 "op": [
                     "observeproperty"
                 ],
                 "modbus:entity": "Coil",
                 "modbus:pollingTime": 1000,
-                "modbus:address": 1
             }
         </pre>
         Finally, [[[#full-td]]] shows a complete device described using Modbus ontology.
@@ -565,7 +579,7 @@
                   },
                   "security": "nosec_sc",
               
-                  "base": "",
+                  "base": "modbus+tcp://192.168.178.32:502/1",
                   "properties": {
                       "limitSwitch1": {
                           "title": "downLimitSwitch",
@@ -574,11 +588,8 @@
                           "forms": [
                               {
                                   "op": "readproperty",
-                                  "href": "modbus+tcp://192.168.178.32:502",
+                                  "href": "./10003",
                                   "modbus:function": "readDiscreteInput",
-                                  "modbus:quantity": 1,
-                                  "modbus:address": 10003,
-                                  "modbus:unitID": 1,
                                   "contentType": "application/octet-stream"
                               }
                           ]
@@ -590,11 +601,8 @@
                           "forms": [
                               {
                                   "op": "readproperty",
-                                  "href": "modbus+tcp://192.168.178.32:502",
+                                  "href": "./10002",
                                   "modbus:function": "readDiscreteInput",
-                                  "modbus:quantity": 1,
-                                  "modbus:address": 10002,
-                                  "modbus:unitID": 1,
                                   "contentType": "application/octet-stream"
                               }
                           ]
@@ -610,11 +618,8 @@
                                       "observeproperty",
                                       "readproperty"
                                   ],
-                                  "href": "modbus+tcp://192.168.178.32:502",
+                                  "href": "./6",
                                   "modbus:entity": "Coil",
-                                  "modbus:quantity": 1,
-                                  "modbus:address": 6,
-                                  "modbus:unitID": 1,
                                   "modbus:pollingTime": 100,
                                   "contentType": "application/octet-stream"
                               }
@@ -631,11 +636,8 @@
                                       "observeproperty",
                                       "readproperty"
                                   ],
-                                  "href": "modbus+tcp://192.168.178.32:502",
+                                  "href": "./3",
                                   "modbus:entity": "Coil",
-                                  "modbus:quantity": 1,
-                                  "modbus:address": 3,
-                                  "modbus:unitID": 1,
                                   "modbus:pollingRate": 100,
                                   "contentType": "application/octet-stream"
                               }
@@ -644,6 +646,17 @@
                   }
               }
               </pre>
+    </section>
+    <section class="appendix" id="abnf">
+        <h2>Modbus URL ABNF syntax</h2>
+        <p>The following describe the [[[#url]]] using [[[RFC2234]]] with the reference to [[[uri]]] specification. </p>
+        <pre class="syntax">
+            MODBUS-URI = "modbus+tcp://" authority path-modbus [ "?quantity=" quantity ]
+            path-modbus = "/" unitID "/" address
+            unitID=1*DIGIT
+            address=1*DIGIT
+            quantity=1*DIGIT
+        </pre>
     </section>
 </body>
 

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -70,7 +70,7 @@
         Considering that in Web of Things context all protocol bindings are required to at least support the Internet Protocol, for the Modbus protocol <code>modbus+tcp://</code> 
         was selected as the only valid URL scheme. The following shows the typical structure of an URL of the Modbus protocol:
         <pre>
-            modbus+tcp://{address}:{port}/{?unitID}
+            modbus+tcp://{address}:{port}/{unitID}/{address}?quantity={?quantity}
         </pre>
 
         <p>
@@ -79,13 +79,33 @@
                 <li><code>{address}</code> is the IP address of the Modbus device</li>
                 <li><code>{port}</code> is the port of the Modbus device</li>
                 <li><code>{unitID}</code> is the unit ID of the Modbus device. See <a href="#vocabulary">vocabulary</a></li>
+                <li><code>{address}</code> is the address of the register/coil referenced in this URL. See <a href="#vocabulary">vocabulary</a></li>
+                <li><code>{quantity}</code> the amount of registers/coils referenced in this URL. See <a href="#vocabulary">vocabulary</a></li>
             </ul>
+            For the full syntax see [[[#abnf]]]
         </p>
     </section>
     <section id="vocabulary">
         <h2>Modbus Vocabulary</h2>
         This section describes the vocabulary used in the Modbus protocol. A protocol binding implementation should use the vocabulary defined in this section to
         describe the different configuration that can be used to exchanged data between Web of Things.
+        <section>
+            <h3>URL terms</h3>
+            <table class="def">
+                <thead>
+                    <tr>
+                        <th>Vocabulary term</th>
+                        <th>Description</th>
+                        <th>Assignment</th>
+                        <th>Type</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- Generate forms terms from the ontology-->
+                    %s
+                </tbody>
+            </table>
+        </section>
         <section>
             <h3>Form terms</h3>
             <table class="def">
@@ -268,32 +288,29 @@
         a short description of the modbus endpoint.
         <pre id="example-read-coil-entity" class="example" title="Read and write single coil">
                     {
-                        "href": "modbus+tcp://127.0.0.1:60000/1",
+                        "href": "modbus+tcp://127.0.0.1:60000/1/1",
                         "op": [
                             "readproperty",
                             "writeproperty"
                         ],
                         "modbus:entity": "Coil",
-                        "modbus:address": 1
                     }
         </pre>
         A TD processor will intepred [[[#example-read-coil-entity]]] configuration as the following:
         <pre id="example-read-coil-entity" class="example" title="Read and write single coil expanded">
                             {
-                                "href": "modbus+tcp://127.0.0.1:60000/1",
+                                "href": "modbus+tcp://127.0.0.1:60000/1/1",
                                 "op": [
                                     "readproperty",
                                 ],
                                 "modbus:function": "readCoil",
-                                "modbus:address": 1
                             },
                             {
-                                "href": "modbus+tcp://127.0.0.1:60000/1",
+                                "href": "modbus+tcp://127.0.0.1:60000/1/1",
                                 "op": [
                                     "writeproperty",
                                 ],
                                 "modbus:function": "writeCoil",
-                                "modbus:address": 1
                             },
         </pre>
         Reducing effectively the verbosity of a TD. 
@@ -303,14 +320,12 @@
         8 HoldingRegisters. 
         <pre id="example-read-holding" class="example" title="Read 8 holding registers">
                             {
-                                "href": "modbus+tcp://127.0.0.1:60000/1",
+                                "href": "modbus+tcp://127.0.0.1:60000/1/40001?quantity=8",
                                 "op": [
                                     "readproperty",
                                     "writeproperty"
                                 ],
-                                "modbus:entity": "HoldingRegister",
-                                "modbus:address": 40001,
-                                "modbus:quantity": 8
+                                "modbus:entity": "HoldingRegister"
                             }
                 </pre>
         When possible WoT consumers will use Modbus features to read the desired amount of data with a single
@@ -319,14 +334,12 @@
         In these circumstances consumers will perform different requests to satisfy the configuration requirements. 
         <pre id="example-read-coil-range" class="example" title="Read and write 8 single coils with one form">
                             {
-                                "href": "modbus+tcp://127.0.0.1:60000/1",
+                                "href": "modbus+tcp://127.0.0.1:60000/1/1?quantity=8",
                                 "op": [
                                     "readproperty",
                                     "writeproperty"
                                 ],
-                                "modbus:entity": "Coil",
-                                "modbus:address": 1,
-                                "modbus:quantity": 8
+                                "modbus:entity": "Coil"
                             }
                 </pre>
         Another notable configuration of a form using the Modbus vocabulary is the polling mechanism. Thanks
@@ -337,13 +350,12 @@
         default for observing a property. 
         <pre  id="example-polling" class="example" title="Polling">
             {
-                "href": "modbus+tcp://127.0.0.1:60000/1",
+                "href": "modbus+tcp://127.0.0.1:60000/1/1",
                 "op": [
                     "observeproperty"
                 ],
                 "modbus:entity": "Coil",
                 "modbus:pollingTime": 1000,
-                "modbus:address": 1
             }
         </pre>
         Finally, [[[#full-td]]] shows a complete device described using Modbus ontology.
@@ -365,7 +377,7 @@
                   },
                   "security": "nosec_sc",
               
-                  "base": "",
+                  "base": "modbus+tcp://192.168.178.32:502/1",
                   "properties": {
                       "limitSwitch1": {
                           "title": "downLimitSwitch",
@@ -374,11 +386,8 @@
                           "forms": [
                               {
                                   "op": "readproperty",
-                                  "href": "modbus+tcp://192.168.178.32:502",
+                                  "href": "./10003",
                                   "modbus:function": "readDiscreteInput",
-                                  "modbus:quantity": 1,
-                                  "modbus:address": 10003,
-                                  "modbus:unitID": 1,
                                   "contentType": "application/octet-stream"
                               }
                           ]
@@ -390,11 +399,8 @@
                           "forms": [
                               {
                                   "op": "readproperty",
-                                  "href": "modbus+tcp://192.168.178.32:502",
+                                  "href": "./10002",
                                   "modbus:function": "readDiscreteInput",
-                                  "modbus:quantity": 1,
-                                  "modbus:address": 10002,
-                                  "modbus:unitID": 1,
                                   "contentType": "application/octet-stream"
                               }
                           ]
@@ -410,11 +416,8 @@
                                       "observeproperty",
                                       "readproperty"
                                   ],
-                                  "href": "modbus+tcp://192.168.178.32:502",
+                                  "href": "./6",
                                   "modbus:entity": "Coil",
-                                  "modbus:quantity": 1,
-                                  "modbus:address": 6,
-                                  "modbus:unitID": 1,
                                   "modbus:pollingTime": 100,
                                   "contentType": "application/octet-stream"
                               }
@@ -431,11 +434,8 @@
                                       "observeproperty",
                                       "readproperty"
                                   ],
-                                  "href": "modbus+tcp://192.168.178.32:502",
+                                  "href": "./3",
                                   "modbus:entity": "Coil",
-                                  "modbus:quantity": 1,
-                                  "modbus:address": 3,
-                                  "modbus:unitID": 1,
                                   "modbus:pollingRate": 100,
                                   "contentType": "application/octet-stream"
                               }
@@ -444,6 +444,17 @@
                   }
               }
               </pre>
+    </section>
+    <section class="appendix" id="abnf">
+        <h2>Modbus URL ABNF syntax</h2>
+        <p>The following describe the [[[#url]]] using [[[RFC2234]]] with the reference to [[[uri]]] specification. </p>
+        <pre class="syntax">
+            MODBUS-URI = "modbus+tcp://" authority path-modbus [ "?quantity=" quantity ]
+            path-modbus = "/" unitID "/" address
+            unitID=1*DIGIT
+            address=1*DIGIT
+            quantity=1*DIGIT
+        </pre>
     </section>
 </body>
 

--- a/bindings/protocols/modbus/template.sparql
+++ b/bindings/protocols/modbus/template.sparql
@@ -16,6 +16,7 @@ prefix : <http://w3c.github.io/wot-binding-templates/mappings#>
 template :modbus {
     format {
         <file://./bindings/protocols/modbus/index.template.html>
+        st:call-template(:urlTerms, ?modbusBase, ?prefix)
         st:call-template(:formTerms, ?modbusBase, ?prefix)
         st:call-template(:entityValues, ?modbusBase, ?prefix)
         st:call-template(:functionValues, ?modbusBase, ?prefix)
@@ -27,6 +28,47 @@ template :modbus {
     ?modbusBase a owl:Ontology;
        vann:preferredNamespacePrefix ?prefix
 }
+
+template :urlTerms(?ns ?prefix){
+    format {
+        """
+        
+        <tr>
+            <td><code>%s</code></td>
+            <td>%s</td>
+            <td>%s</td>
+            <td><a href=\"%s\">%s</a></td>
+
+        <tr>
+        """
+        st:call-template(:term, ?ns, ?prefix, ?term)
+        ?desc
+        if(?count > 0, "required","optional")
+        if(strstarts(?type,str(?ns)), lcase(replace(?type, ?ns,"","g")),?type )
+        strafter(?type,"#")
+
+    }
+} where {
+    ?shape a sh:NodeShape ;
+        sh:targetClass hctl:Form ;
+        sh:order 1 ;
+        sh:property ?property.
+    
+    ?property sh:path ?term .
+    ?term rdfs:comment ?desc .
+    optional {
+        ?property sh:minCount ?count 
+    }
+    optional {
+        ?property sh:class ?type
+    }
+    optional {
+        ?property sh:datatype ?type
+    }
+    
+    BIND ( IF (BOUND (?count), ?count, 0 )  as ?count  )
+    filter( ?term = concat(?ns,"#hasAddress" ) || ?term = concat(?ns,"#hasUnitID" ) ||  ?term = concat(?ns,"#hasQuantity" ))
+} 
 
 template :formTerms(?ns ?prefix){
     format {
@@ -65,6 +107,8 @@ template :formTerms(?ns ?prefix){
     }
     
     BIND ( IF (BOUND (?count), ?count, 0 )  as ?count  )
+    # Filter out URL terms
+    filter( ?term != concat(?ns,"#hasAddress" ) && ?term != concat(?ns,"#hasUnitID" ) &&  ?term != concat(?ns,"#hasQuantity" ))
    
 } 
 


### PR DESCRIPTION
This PR addresses the concerns raised in #176. Some possible discussion points:
- I stick with the familiar key=value syntax for the `quantity` parameter but in theory, we can shrink to just the number as we are defining the URL syntax ourselves
- I tried to keep the current document structure intact and just moved `unitID`, `address`, `quantity` to a dedicated section called URL terms. 
- I also added a very simple ABNF syntax for formally describing the components of the URL. Perhaps it is too much. 

Fixes #176 