### PR TITLE
Align protocol binding abstracts

### DIFF
--- a/bindings/index.template.html
+++ b/bindings/index.template.html
@@ -21,7 +21,7 @@
                 data: [
                     {
                     value: "Web of Things (WoT) Binding Templates",
-                    href: "../../index.html"
+                    href: "../../../index.html"
                     }
                 ]
                 }

--- a/bindings/index.template.html
+++ b/bindings/index.template.html
@@ -36,7 +36,8 @@
         <p class="ednote">Please update according to the binding in question. Make sure to replace X with the binding in question.</p>
         <p>
             In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
-            implement a specific IoT protocol, data format or IoT platform. 
+            implement a specific IoT protocol, data format or IoT platform.
+            The Core Binding Templates specification explains the overall mechanism and requirements for any binding to follow.
             This document gives implementation guidelines regarding the X, which is used here and there, has features Y and Z.
             <!-- Please make sure that the part starts by "This document" is not longer than 2 or 3 sentences and it is objective,
             i.e. do not say it is the best protocol to do something -->

--- a/bindings/index.template.html
+++ b/bindings/index.template.html
@@ -16,6 +16,16 @@
             edDraftURI: "https://w3c.github.io/wot-binding-templates/BINDINGNAME",
             github: "https://github.com/w3c/wot-binding-templates",// please do not change this
             shortName: "wot-BINDINGNAME-template", // or "wot-BINDINGNAME-binding"
+            otherLinks: [{
+                key: "Core Binding Templates Specification",
+                data: [
+                    {
+                    value: "Web of Things (WoT) Binding Templates",
+                    href: "../../index.html"
+                    }
+                ]
+                }
+            ]
         };
     </script>
     <title>Web of Things (WoT) BINDINGNAME Binding Template</title>

--- a/bindings/index.template.html
+++ b/bindings/index.template.html
@@ -23,7 +23,19 @@
 
 <body>
     <section id='abstract'>
-        <p class="ednote">TODO: Provide a short overview of the document and the protocol binding features.</p>
+        <p class="ednote">Please update according to the binding in question. Make sure to replace X with the binding in question.</p>
+        <p>
+            In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
+            implement a specific IoT protocol, data format or IoT platform. 
+            This document gives implementation guidelines regarding the X, which is used here and there, has features Y and Z.
+            <!-- Please make sure that the part starts by "This document" is not longer than 2 or 3 sentences and it is objective,
+            i.e. do not say it is the best protocol to do something -->
+        </p>
+        <p>
+            More specifically, this document defines a set of vocabulary terms that can be used inside a Thing Description document, 
+            and associated rules which allow to describe WoT operations using X over the network.
+            Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
+        </p>
     </section>
     <section id='introduction'>
         <h2>Introduction</h2>

--- a/bindings/payloads/xml/index.html
+++ b/bindings/payloads/xml/index.html
@@ -23,13 +23,14 @@
             edDraftURI: "https://w3c.github.io/wot-binding-templates/bindings/payloads/xml/",
             shortName: "wot-xml-template",
             github: "https://github.com/w3c/wot-binding-templates",
-            otherLinks: [
-                {
-                    key: "Other documentation",
-                    data: [{
-                        value: "In the GitHub repository",
-                        href: "https://github.com/w3c/wot-binding-templates/graphs/contributors"
-                    }]
+            otherLinks: [{
+                key: "Core Binding Templates Specification",
+                data: [
+                    {
+                    value: "Web of Things (WoT) Binding Templates",
+                    href: "../../index.html"
+                    }
+                ]
                 }
             ]
         };

--- a/bindings/payloads/xml/index.html
+++ b/bindings/payloads/xml/index.html
@@ -28,7 +28,7 @@
                 data: [
                     {
                     value: "Web of Things (WoT) Binding Templates",
-                    href: "../../index.html"
+                    href: "../../../index.html"
                     }
                 ]
                 }

--- a/bindings/platforms/hue/index.html
+++ b/bindings/platforms/hue/index.html
@@ -22,13 +22,14 @@
             edDraftURI: "https://w3c.github.io/wot-binding-templates/bindings/platforms/hue/",
             github: "https://github.com/w3c/wot-binding-templates",
             shortName: "wot-hue-template",
-            otherLinks: [
-                {
-                    key: "Other documentation",
-                    data: [{
-                        value: "In the GitHub repository",
-                        href: "https://github.com/w3c/wot-binding-templates/graphs/contributors"
-                    }]
+            otherLinks: [{
+                key: "Core Binding Templates Specification",
+                data: [
+                    {
+                    value: "Web of Things (WoT) Binding Templates",
+                    href: "../../index.html"
+                    }
+                ]
                 }
             ]
         };

--- a/bindings/platforms/hue/index.html
+++ b/bindings/platforms/hue/index.html
@@ -27,7 +27,7 @@
                 data: [
                     {
                     value: "Web of Things (WoT) Binding Templates",
-                    href: "../../index.html"
+                    href: "../../../index.html"
                     }
                 ]
                 }

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -17,6 +17,16 @@
             edDraftURI: "https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/",
             shortName: "wot-coap-binding",
             github: "https://github.com/w3c/wot-binding-templates",
+            otherLinks: [{
+                key: "Core Binding Templates Specification",
+                data: [
+                    {
+                    value: "Web of Things (WoT) Binding Templates",
+                    href: "../../index.html"
+                    }
+                ]
+                }
+            ]
         };
     </script>
     <title>Web of Things (WoT) CoAP Binding Template</title>

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -22,7 +22,7 @@
                 data: [
                     {
                     value: "Web of Things (WoT) Binding Templates",
-                    href: "../../index.html"
+                    href: "../../../index.html"
                     }
                 ]
                 }

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -24,7 +24,17 @@
 
 <body>
     <section id='abstract'>
-        <p class="ednote">TODO: Provide a short overview of the document and the protocol binding features.</p>
+        <p>
+            In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
+            implement a specific IoT protocol, data format or IoT platform. 
+            This document gives implementation guidelines regarding the Constrained Application Protocol (CoAP), which 
+            is a specialized web transfer protocol for use with constrained nodes and constrained (e.g., low-power, lossy) networks.. 
+        </p>
+        <p>
+            More specifically, this document defines a set of vocabulary terms that can be used inside a Thing Description document, 
+            and associated rules which allow to describe WoT operations using CoAP over the network.
+            Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
+        </p>
     </section>
     <section id='introduction'>
         <h2>Introduction</h2>

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -28,7 +28,7 @@
             In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
             implement a specific IoT protocol, data format or IoT platform. 
             This document gives implementation guidelines regarding the Constrained Application Protocol (CoAP), which 
-            is a specialized web transfer protocol for use with constrained nodes and constrained (e.g., low-power, lossy) networks.. 
+            is a specialized web transfer protocol for use with constrained nodes and constrained (e.g., low-power, lossy) networks.
         </p>
         <p>
             More specifically, this document defines a set of vocabulary terms that can be used inside a Thing Description document, 

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -36,7 +36,8 @@
     <section id='abstract'>
         <p>
             In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
-            implement a specific IoT protocol, data format or IoT platform. 
+            implement a specific IoT protocol, data format or IoT platform.
+            The Core Binding Templates specification explains the overall mechanism and requirements for any binding to follow.
             This document gives implementation guidelines regarding the Constrained Application Protocol (CoAP), which 
             is a specialized web transfer protocol for use with constrained nodes and constrained (e.g., low-power, lossy) networks.
         </p>

--- a/bindings/protocols/http/index.html
+++ b/bindings/protocols/http/index.html
@@ -23,6 +23,16 @@
             edDraftURI: "https://w3c.github.io/wot-binding-templates/bindings/protocols/http/",
             shortName: "wot-http-binding",
             github: "https://github.com/w3c/wot-binding-templates",
+            otherLinks: [{
+                key: "Core Binding Templates Specification",
+                data: [
+                    {
+                    value: "Web of Things (WoT) Binding Templates",
+                    href: "../../index.html"
+                    }
+                ]
+                }
+            ]
         };
     </script>
     <title>Web of Things (WoT) HTTP Binding Template</title>

--- a/bindings/protocols/http/index.html
+++ b/bindings/protocols/http/index.html
@@ -43,7 +43,8 @@
         <h2>Abstract</h2>
         <p>
             In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
-            implement a specific IoT protocol, data format or IoT platform. 
+            implement a specific IoT protocol, data format or IoT platform.
+            The Core Binding Templates specification explains the overall mechanism and requirements for any binding to follow.
             This document gives implementation guidelines regarding the Hypertext Transfer Protocol (HTTP), which is one of the most used protocols
             in the Internet to exchange any kind of data related to Webpages, Web APIs, IoT devices and much more. 
         </p>

--- a/bindings/protocols/http/index.html
+++ b/bindings/protocols/http/index.html
@@ -28,7 +28,7 @@
                 data: [
                     {
                     value: "Web of Things (WoT) Binding Templates",
-                    href: "../../index.html"
+                    href: "../../../index.html"
                     }
                 ]
                 }

--- a/bindings/protocols/http/index.html
+++ b/bindings/protocols/http/index.html
@@ -32,7 +32,15 @@
     <section id="abstract">
         <h2>Abstract</h2>
         <p>
-            <p class="ednote">TODO</p>
+            In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
+            implement a specific IoT protocol, data format or IoT platform. 
+            This document gives implementation guidelines regarding the Hypertext Transfer Protocol (HTTP), which is one of the most used protocols
+            in the Internet to exchange any kind of data related to Webpages, Web APIs, IoT devices and much more. 
+        </p>
+        <p>
+            More specifically, it defines a set of vocabulary terms that can be used inside a Thing Description document, 
+            and associated rules which allow to describe WoT operations using HTTP over the network.
+            Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
         </p>
     </section>
     <section id='introduction'>

--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -26,15 +26,15 @@
 <body>
     <section id='abstract'>
         <p>
-            In the context of the <a href="https://www.w3.org/TR/wot-architecture/">Web of Things (WoT)</a>, a Binding Template is a blueprint that gives 
-            guidance on how to implement a specific IoT protocol, data format or IoT platform. This document gives implementation guidelines regarding
-            the <a href='https://www.modbus.org/'>Modbus protocol</a>. Modbus protocol is a well-known cost-effective IoT protocol for communication between
-            industrial control and automation devices. 
+            In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
+            implement a specific IoT protocol, data format or IoT platform. 
+            This document gives implementation guidelines regarding the Modbus protocol, which is a well-known 
+            cost-effective IoT protocol for communication between industrial control and automation devices. 
         </p>
         <p>
-            The following defines a set of standard terms and rules with relevant examples that can be used inside
-            a <a href="https://www.w3.org/TR/wot-thing-description/">Thing Description document</a> to describe a WoT operation using the Modbus protocol
-            over the network.
+            More specifically, this document defines a set of vocabulary terms that can be used inside a Thing Description document, 
+            and associated rules which allow to describe WoT operations using the Modbus protocol over the network.
+            Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
         </p>
     </section>
     <section id='introduction'>

--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -23,7 +23,7 @@
                 data: [
                     {
                     value: "Web of Things (WoT) Binding Templates",
-                    href: "../../index.html"
+                    href: "../../../index.html"
                     }
                 ]
                 }

--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -18,6 +18,16 @@
             edDraftURI: "https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/",
             shortName: "wot-modbus-binding",
             github: "https://github.com/w3c/wot-binding-templates",
+            otherLinks: [{
+                key: "Core Binding Templates Specification",
+                data: [
+                    {
+                    value: "Web of Things (WoT) Binding Templates",
+                    href: "../../index.html"
+                    }
+                ]
+                }
+            ]
         };
     </script>
     <title>Web of Things (WoT) Modbus Binding Template</title>

--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -37,7 +37,8 @@
     <section id='abstract'>
         <p>
             In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
-            implement a specific IoT protocol, data format or IoT platform. 
+            implement a specific IoT protocol, data format or IoT platform.
+            The Core Binding Templates specification explains the overall mechanism and requirements for any binding to follow.
             This document gives implementation guidelines regarding the Modbus protocol, which is a well-known 
             cost-effective IoT protocol for communication between industrial control and automation devices. 
         </p>

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -26,15 +26,15 @@
 <body>
     <section id='abstract'>
         <p>
-            In the context of the <a href="https://www.w3.org/TR/wot-architecture/">Web of Things (WoT)</a>, a Binding Template is a blueprint that gives 
-            guidance on how to implement a specific IoT protocol, data format or IoT platform. This document gives implementation guidelines regarding
-            the <a href='https://www.modbus.org/'>Modbus protocol</a>. Modbus protocol is a well-known cost-effective IoT protocol for communication between
-            industrial control and automation devices. 
+            In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
+            implement a specific IoT protocol, data format or IoT platform. 
+            This document gives implementation guidelines regarding the Modbus protocol, which is a well-known 
+            cost-effective IoT protocol for communication between industrial control and automation devices. 
         </p>
         <p>
-            The following defines a set of standard terms and rules with relevant examples that can be used inside
-            a <a href="https://www.w3.org/TR/wot-thing-description/">Thing Description document</a> to describe a WoT operation using the Modbus protocol
-            over the network.
+            More specifically, this document defines a set of vocabulary terms that can be used inside a Thing Description document, 
+            and associated rules which allow to describe WoT operations using the Modbus protocol over the network.
+            Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
         </p>
     </section>
     <section id='introduction'>

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -23,7 +23,7 @@
                 data: [
                     {
                     value: "Web of Things (WoT) Binding Templates",
-                    href: "../../index.html"
+                    href: "../../../index.html"
                     }
                 ]
                 }

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -18,6 +18,16 @@
             edDraftURI: "https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/",
             shortName: "wot-modbus-binding",
             github: "https://github.com/w3c/wot-binding-templates",
+            otherLinks: [{
+                key: "Core Binding Templates Specification",
+                data: [
+                    {
+                    value: "Web of Things (WoT) Binding Templates",
+                    href: "../../index.html"
+                    }
+                ]
+                }
+            ]
         };
     </script>
     <title>Web of Things (WoT) Modbus Binding Template</title>

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -37,7 +37,8 @@
     <section id='abstract'>
         <p>
             In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
-            implement a specific IoT protocol, data format or IoT platform. 
+            implement a specific IoT protocol, data format or IoT platform.
+            The Core Binding Templates specification explains the overall mechanism and requirements for any binding to follow.
             This document gives implementation guidelines regarding the Modbus protocol, which is a well-known 
             cost-effective IoT protocol for communication between industrial control and automation devices. 
         </p>

--- a/bindings/protocols/mqtt/index.html
+++ b/bindings/protocols/mqtt/index.html
@@ -63,7 +63,7 @@
         <p>
             In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
             implement a specific IoT protocol, data format or IoT platform. 
-            This document gives implementation guidelines regarding the MQ Telemetry Transport (MQTT) protocol, which is
+            This document gives implementation guidelines regarding the MQTT protocol, which is
             a lightweight, asynchronous, transport-independent, open protocol for publishing and subscribing to messages. 
             It has been employed in many IoT platforms and IoT applications for its simplicity and scalability.
         </p>

--- a/bindings/protocols/mqtt/index.html
+++ b/bindings/protocols/mqtt/index.html
@@ -60,11 +60,18 @@
 
 <body>
     <section id="abstract">
-      In the context of the Web of Things, a Binding Template is 
-      a blueprint that gives guidance on how to implement a specific IoT protocol, data format or IoT platform. 
-      This document gives implementation guidelines regarding the MQTT protocol. 
-      The MQTT protocol is a lightweight, asynchronous, transport-independent, open protocol for publishing and subscribing to messages. 
-      It has been employed in many IoT platforms and IoT applications for its simplicity and scalability.
+        <p>
+            In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
+            implement a specific IoT protocol, data format or IoT platform. 
+            This document gives implementation guidelines regarding the MQ Telemetry Transport (MQTT) protocol, which is
+            a lightweight, asynchronous, transport-independent, open protocol for publishing and subscribing to messages. 
+            It has been employed in many IoT platforms and IoT applications for its simplicity and scalability.
+        </p>
+        <p>
+            More specifically, this document defines a set of vocabulary terms that can be used inside a Thing Description document, 
+            and associated rules which allow to describe WoT operations using the MQTT protocol over the network.
+            Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
+        </p>
     </section>
     <section id='introduction'>
         <h2>Introduction</h2>

--- a/bindings/protocols/mqtt/index.html
+++ b/bindings/protocols/mqtt/index.html
@@ -72,7 +72,8 @@
     <section id="abstract">
         <p>
             In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
-            implement a specific IoT protocol, data format or IoT platform. 
+            implement a specific IoT protocol, data format or IoT platform.
+            The Core Binding Templates specification explains the overall mechanism and requirements for any binding to follow.
             This document gives implementation guidelines regarding the MQTT protocol, which is
             a lightweight, asynchronous, transport-independent, open protocol for publishing and subscribing to messages. 
             It has been employed in many IoT platforms and IoT applications for its simplicity and scalability.

--- a/bindings/protocols/mqtt/index.html
+++ b/bindings/protocols/mqtt/index.html
@@ -52,7 +52,17 @@
                 , publisher: "W3C"
                 , date: "June 2022"
               }
-            }
+            },
+            otherLinks: [{
+                key: "Core Binding Templates Specification",
+                data: [
+                    {
+                    value: "Web of Things (WoT) Binding Templates",
+                    href: "../../index.html"
+                    }
+                ]
+                }
+            ]
         };
     </script>
     <title>Web of Things (WoT) MQTT Binding Template</title>

--- a/bindings/protocols/mqtt/index.html
+++ b/bindings/protocols/mqtt/index.html
@@ -58,7 +58,7 @@
                 data: [
                     {
                     value: "Web of Things (WoT) Binding Templates",
-                    href: "../../index.html"
+                    href: "../../../index.html"
                     }
                 ]
                 }

--- a/bindings/protocols/mqtt/index.template.html
+++ b/bindings/protocols/mqtt/index.template.html
@@ -63,7 +63,7 @@
         <p>
             In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
             implement a specific IoT protocol, data format or IoT platform. 
-            This document gives implementation guidelines regarding the MQ Telemetry Transport (MQTT) protocol, which is
+            This document gives implementation guidelines regarding the MQTT protocol, which is
             a lightweight, asynchronous, transport-independent, open protocol for publishing and subscribing to messages. 
             It has been employed in many IoT platforms and IoT applications for its simplicity and scalability.
         </p>

--- a/bindings/protocols/mqtt/index.template.html
+++ b/bindings/protocols/mqtt/index.template.html
@@ -60,11 +60,18 @@
 
 <body>
     <section id="abstract">
-      In the context of the Web of Things, a Binding Template is 
-      a blueprint that gives guidance on how to implement a specific IoT protocol, data format or IoT platform. 
-      This document gives implementation guidelines regarding the MQTT protocol. 
-      The MQTT protocol is a lightweight, asynchronous, transport-independent, open protocol for publishing and subscribing to messages. 
-      It has been employed in many IoT platforms and IoT applications for its simplicity and scalability.
+        <p>
+            In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
+            implement a specific IoT protocol, data format or IoT platform. 
+            This document gives implementation guidelines regarding the MQ Telemetry Transport (MQTT) protocol, which is
+            a lightweight, asynchronous, transport-independent, open protocol for publishing and subscribing to messages. 
+            It has been employed in many IoT platforms and IoT applications for its simplicity and scalability.
+        </p>
+        <p>
+            More specifically, this document defines a set of vocabulary terms that can be used inside a Thing Description document, 
+            and associated rules which allow to describe WoT operations using the MQTT protocol over the network.
+            Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
+        </p>
     </section>
     <section id='introduction'>
         <h2>Introduction</h2>

--- a/bindings/protocols/mqtt/index.template.html
+++ b/bindings/protocols/mqtt/index.template.html
@@ -72,7 +72,8 @@
     <section id="abstract">
         <p>
             In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to 
-            implement a specific IoT protocol, data format or IoT platform. 
+            implement a specific IoT protocol, data format or IoT platform.
+            The Core Binding Templates specification explains the overall mechanism and requirements for any binding to follow.
             This document gives implementation guidelines regarding the MQTT protocol, which is
             a lightweight, asynchronous, transport-independent, open protocol for publishing and subscribing to messages. 
             It has been employed in many IoT platforms and IoT applications for its simplicity and scalability.

--- a/bindings/protocols/mqtt/index.template.html
+++ b/bindings/protocols/mqtt/index.template.html
@@ -52,7 +52,17 @@
                 , publisher: "W3C"
                 , date: "June 2022"
               }
-            }
+            },
+            otherLinks: [{
+                key: "Core Binding Templates Specification",
+                data: [
+                    {
+                    value: "Web of Things (WoT) Binding Templates",
+                    href: "../../index.html"
+                    }
+                ]
+                }
+            ]
         };
     </script>
     <title>Web of Things (WoT) MQTT Binding Template</title>

--- a/bindings/protocols/mqtt/index.template.html
+++ b/bindings/protocols/mqtt/index.template.html
@@ -58,7 +58,7 @@
                 data: [
                     {
                     value: "Web of Things (WoT) Binding Templates",
-                    href: "../../index.html"
+                    href: "../../../index.html"
                     }
                 ]
                 }


### PR DESCRIPTION
This PR touches all protocol bindings, thus I have requested review from all current editors and active contributors. However, there is no obligation to read and review all of them. It would be best if you can review the documents you have contributed to and the template, that would be enough.

My reasoning is to use a single template that changes per protocol binding. Having a common image is important in my opinion since all these documents can be accessed independent of the other and of the main document.