### PR TITLE
Remove ontology link from coap

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,7 +272,7 @@
                         <td>CoAP</td>
                         <td>Constrained Application Protocol</td>
                         <td><a href="./bindings/protocols/coap/index.html">Binding Template</a></td>
-                        <td><a href="./ontology/coap.html">Ontology</a></td>
+                        <td>Not available</td>
                     </tr>
                     <tr>
                         <td>MQTT</td>


### PR DESCRIPTION
This removes it from the core document


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/pull/211.html" title="Last updated on Nov 30, 2022, 1:52 PM UTC (208874c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/211/2d7db55...208874c.html" title="Last updated on Nov 30, 2022, 1:52 PM UTC (208874c)">Diff</a>