### PR TITLE
Orphaned Section Reorg - Part 1: Protocols

### DIFF
--- a/index.html
+++ b/index.html
@@ -941,8 +941,8 @@
         
     </section>
 
-    <section id="sec-orphaned">
-        <h2>Orphaned Sections</h2>
+    <section id="sec-temp">
+        <h2>Temporary Sections</h2>
 
         <p class="ednote">
             The below chapters are copied from other places in this document. They require discussion on where to place

--- a/index.html
+++ b/index.html
@@ -255,6 +255,12 @@
         <section id="protocol-intro">
             <h3>Protocol Binding Templates</h3>
             <p>
+                [[WOT-THING-DESCRIPTION]] defines abstract operations such as <code>readproperty</code>, <code>invokeaction</code> and
+                <code>subscribeevent</code> that describe the intended semantics of performing the operation described by the form.
+                In order for the operations to be performed on the affordance, a binding of the operation to the 
+                protocol needs to happen.
+            </p>
+            <p>
                 Most protocols have a relatively small set of methods that define the message type, the semantic
                 intention of the message.
                 REST and PubSub architecture patterns result in different protocols with different methods.
@@ -906,10 +912,6 @@
         
             <section id="operation-types">
                 <h2>Operation Types</h2>
-                <p>
-                    Form Operation Types describe the intended semantics of performing the operation
-                    described by the form.
-                </p>
                 <p>
                     For example, the Property interaction allows read and write operations. The
                     protocol binding may contain a form for the read operation and a different

--- a/index.html
+++ b/index.html
@@ -300,7 +300,7 @@
                             </pre>
                         </td>
                         <td style="vertical-align: top; width: 50%">
-                            <pre class="example" title="Binding example of an invokeaction operation to Modbus">
+                            <pre class="example" title="Binding example of an readproperty operation to Modbus">
                                 {
                                     "href": "modbus+tcp://127.0.0.1:60000/1",
                                     "op": "readproperty",

--- a/index.html
+++ b/index.html
@@ -285,45 +285,81 @@
                 in different cases of protocol usage.
             </p>
             <p>
-                The table below summarizes the currently specified protocols in their respective <a>Binding Template Subspecification</a>.
+                The examples below shows the binding of the <code>readproperty</code> operation for the HTTP and Modbus protocols.
             </p>
-            <table class="def">
-                <thead>
-                    <tr>
-                        <th>Abbreviation</th>
-                        <th>Name</th>
-                        <th>Link to Binding Template</th>
-                        <th>Link to Ontology</th>
-                    </tr>
-                </thead>
+            <table>
                 <tbody>
                     <tr>
-                        <td>HTTP</td>
-                        <td>Hypertext Transfer Protocol</td>
-                        <td><a href="./bindings/protocols/http/index.html">Binding Template</a></td>
-                        <td><a href="https://www.w3.org/TR/HTTP-in-RDF10/">Ontology</a></td>
-                    </tr>
-                    <tr>
-                        <td>CoAP</td>
-                        <td>Constrained Application Protocol</td>
-                        <td><a href="./bindings/protocols/coap/index.html">Binding Template</a></td>
-                        <td>Not available</td>
-                    </tr>
-                    <tr>
-                        <td>MQTT</td>
-                        <td>Message Queuing Telemetry Transport</td>
-                        <td><a href="./bindings/protocols/mqtt/index.html">Binding Template</a></td>
-                        <td><a href="./ontology/mqtt.html">Ontology</a></td>
-                    </tr>
-                    <tr>
-                        <td>Modbus</td>
-                        <td>Modbus</td>
-                        <td><a href="./bindings/protocols/modbus/index.html">Binding Template</a></td>
-                        <td><a href="./ontology/modbus.html">Ontology</a></td>
+                        <td style="vertical-align: top; width: 50%">
+                            <pre class="example" title="Binding example of a readproperty operation to HTTP">
+                                {
+                                    "href": "http://example.com/props/temperature",
+                                    "op": "readproperty",
+                                    "htv:methodName": "GET"
+                                }
+                            </pre>
+                        </td>
+                        <td style="vertical-align: top; width: 50%">
+                            <pre class="example" title="Binding example of an invokeaction operation to Modbus">
+                                {
+                                    "href": "modbus+tcp://127.0.0.1:60000/1",
+                                    "op": "readproperty",
+                                    "modbus:function": "readCoil",
+                                    "modbus:address": 1
+                                }
+                            </pre>
+                        </td>
                     </tr>
                 </tbody>
             </table>
+
+            <p>
+                In some cases, header options or other parameters of the protocols need to be included.
+                Give 
+            </p>
         
+            <section id="protocol-bindings-table">
+                <h4>Existing Protocol Binding Templates</h4>
+                <p>
+                    The table below summarizes the currently specified protocols in their respective <a>Binding Template Subspecification</a>.
+                </p>
+                <table class="def">
+                    <thead>
+                        <tr>
+                            <th>Abbreviation</th>
+                            <th>Name</th>
+                            <th>Link to Binding Template</th>
+                            <th>Link to Ontology</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>HTTP</td>
+                            <td>Hypertext Transfer Protocol</td>
+                            <td><a href="./bindings/protocols/http/index.html">Binding Template</a></td>
+                            <td><a href="https://www.w3.org/TR/HTTP-in-RDF10/">Ontology</a></td>
+                        </tr>
+                        <tr>
+                            <td>CoAP</td>
+                            <td>Constrained Application Protocol</td>
+                            <td><a href="./bindings/protocols/coap/index.html">Binding Template</a></td>
+                            <td>Not available</td>
+                        </tr>
+                        <tr>
+                            <td>MQTT</td>
+                            <td>Message Queuing Telemetry Transport</td>
+                            <td><a href="./bindings/protocols/mqtt/index.html">Binding Template</a></td>
+                            <td><a href="./ontology/mqtt.html">Ontology</a></td>
+                        </tr>
+                        <tr>
+                            <td>Modbus</td>
+                            <td>Modbus</td>
+                            <td><a href="./bindings/protocols/modbus/index.html">Binding Template</a></td>
+                            <td><a href="./ontology/modbus.html">Ontology</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
             <section>
                 <h4>Creating a new Protocol Binding Template Subspecification</h4>
         
@@ -952,18 +988,6 @@
         
             <section id="protocol-methods-options">
                 <h2>Protocol Methods and Options</h2>
-        
-                <p>
-                    The example below shows some method definitions for various protocols.
-                </p>
-        
-                <pre class="example" title="Vocabulary Example for Methods">
-                                "htv:methodName": "GET"
-        
-                                "mqv:controlPacketValue": "SUBSCRIBE"
-        
-                                "cov:methodName": "GET"
-                            </pre>
         
                 <p>
                     Header options in HTTP, CoAP, MQTT sometimes must be included in a protocol binding in order to

--- a/index.html
+++ b/index.html
@@ -315,7 +315,7 @@
 
             <p>
                 In some cases, header options or other parameters of the protocols need to be included.
-                Give 
+                Given that these are highly protocol dependent, please refer to the bindings listed in [[[#protocol-bindings-table]]]
             </p>
         
             <section id="protocol-bindings-table">
@@ -988,31 +988,6 @@
         
             <section id="protocol-methods-options">
                 <h2>Protocol Methods and Options</h2>
-        
-                <p>
-                    Header options in HTTP, CoAP, MQTT sometimes must be included in a protocol binding in order to
-                    successfully interact with the underlying protocol. The example below shows the structure of
-                    the definition for HTTP header options, according to the W3C HTTP Vocabulary in RDF.
-                </p>
-        
-                <pre class="example" title="HTTP Vocabulary Example for Header Options">
-                    "htv:headers":
-                    [
-                        {
-                        "htv:fieldName": "Accept",
-                        "htv:fieldValue": "application/json"
-                        },
-                        {
-                        "htv:fieldName": "Transfer-Encoding",
-                        "htv:fieldValue": "chunked"
-                        }
-                    ]
-                </pre>
-        
-                <p>
-                    Note: different forms in a binding may need different header constructions,
-                    therefore the <code>htv:headers</code> construct is an extension of the TD "form" element.
-                </p>
         
                 <p>
                     Protocols may have defined sub-protocols that can be used for some interaction

--- a/index.html
+++ b/index.html
@@ -360,9 +360,6 @@
                 </p>
         
             </section>
-            <p class="ednote">
-                The rest of this chapter (4.1.2) is not restructured yet
-            </p>
         
         </section>
         

--- a/index.html
+++ b/index.html
@@ -256,22 +256,33 @@
             <h3>Protocol Binding Templates</h3>
             <p>
                 [[WOT-THING-DESCRIPTION]] defines abstract operations such as <code>readproperty</code>, <code>invokeaction</code> and
-                <code>subscribeevent</code> that describe the intended semantics of performing the operation described by the form.
+                <code>subscribeevent</code> that describe the intended semantics of performing the operation described 
+                by the form in a <a>Thing Description</a>.
                 In order for the operations to be performed on the affordance, a binding of the operation to the 
                 protocol needs to happen.
+                In other words, the form needs to contain all the information for a Consumer to, for example read a property,
+                 with the protocol in the form.
             </p>
             <p>
                 Most protocols have a relatively small set of methods that define the message type, the semantic
                 intention of the message.
                 REST and PubSub architecture patterns result in different protocols with different methods.
-                Common methods found in these protocols are GET, PUT, POST, DELETE, PUBLISH, and SUBSCRIBE.
-                Binding Templates describe how these existing methods and vocabularies can be described in a Thing
-                Description.
+                Each target protocol may specify different method names for similar operations, and there may be 
+                semantic differences between similar method names of different protocols.
+                Additionally, <a>Things</a> may use different methods for performing a particular WoT operation. 
+                For example, an HTTP POST request may be used for a <code>writeproperty</code> operation in one Thing, 
+                while HTTP PUT may be used in another. 
+                For these reasons, Thing Descriptions require the ability to specify which method to use per operation. 
             </p>
             <p>
+                Common methods found in REST and PubSub protocols are GET, PUT, POST, DELETE, PUBLISH, and SUBSCRIBE.
+                Binding Templates describe how these existing methods and associated vocabularies can be used in 
+                a <a>Thing Description</a> to bind to the WoT operations.
                 This is done by defining the URI scheme of the protocol and mapping the protocol
                 methods to the abstract WoT operations such as <code>readproperty</code>, <code>invokeaction</code> and
                 <code>subscribeevent</code>.
+                In some cases, additional instructions are provided to explain how the vocabulary terms should be used 
+                in different cases of protocol usage.
             </p>
             <p>
                 The table below summarizes the currently specified protocols in their respective <a>Binding Template Subspecification</a>.
@@ -910,27 +921,6 @@
                 between the Consumer and the Thing for the interaction.
             </p>
         
-            <section id="operation-types">
-                <h2>Operation Types</h2>
-                <p>
-                    For example, the Property interaction allows read and write operations. The
-                    protocol binding may contain a form for the read operation and a different
-                    form for the write operation. The value of the <code>op</code> attribute of the form
-                    indicates which form is which and allows the Consumer to select the correct
-                    form for the operation required.
-                </p>
-        
-                <pre class="example" title="Form Operation Types">
-                    "op": "readproperty"
-                    "op": "writeproperty"
-                </pre>
-        
-                <p>
-                    The vocabulary in section 4 lists the recommended set of form operations,
-                    and the full TD examples in section 5 contain example uses of form operations types.
-                </p>
-            </section>
-        
             <section id="content-types">
                 <h2>Content Types</h2>
                 <p>
@@ -962,24 +952,6 @@
         
             <section id="protocol-methods-options">
                 <h2>Protocol Methods and Options</h2>
-                <p>
-                    Each target protocol may specify different method names for similar
-                    operations, and there may be semantic differences between similar method names of
-                    different protocols. Additionally, platforms may use different methods
-                    for realizing a particular WoT Interaction Affordance. For example, POST may
-                    be used for writing a Property value in one platform, while PUT may be
-                    used in another. For these reasons, we require the ability to specify
-                    which method to use for a particular Interaction. We also will provide
-                    vocabulary to differentiate between methods of different protocols.
-                </p>
-                <p>
-                    The W3C RDF vocabulary for HTTP [[HTTP-in-RDF10]] is used to identify the methods
-                    and options specified in the HTTP protocol bindings.
-                </p>
-                <p>
-                    For the sake of consistency, we will use the same ontology design pattern
-                    to derive a vocabulary for each target protocol, e.g. CoAP, MQTT.
-                </p>
         
                 <p>
                     The example below shows some method definitions for various protocols.


### PR DESCRIPTION
I have started working on #220. Since there are many sections there, in order to allow reviews, I want to split it as much as possible. In this PR, I am addressing section B.1 at https://w3c.github.io/wot-binding-templates/#form-element . 

To make it easier to review, I have made sure to split commits into meaningful sections. So for an in-depth review, please look at changes per commit.

Working on this PR made me question the need for [B.3 Interaction Affordances](https://w3c.github.io/wot-binding-templates/#sec-interaction-patterns) which is what this section does but per affordance type. I would like to get feedback if we need that.

Subprotocol orphaned section is still there. I am guessing that it will go into the protocol bindings section as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/pull/223.html" title="Last updated on Dec 21, 2022, 5:02 PM UTC (dabd904)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/223/a3e0636...dabd904.html" title="Last updated on Dec 21, 2022, 5:02 PM UTC (dabd904)">Diff</a>