### PR TITLE
JSON Schema usage in Bindings

### DIFF
--- a/bindings/index.template.html
+++ b/bindings/index.template.html
@@ -24,7 +24,16 @@
                     href: "../../../index.html"
                     }
                 ]
-                }
+                },
+                {
+                  key: "JSON Schema",
+                  data: [
+                      {
+                      value: "BINDINGNAME JSON Schema",
+                      href: "template.schema.json"
+                      }
+                  ]
+              }
             ]
         };
     </script>

--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -36,6 +36,15 @@
                       href: "../../../ontology/modbus.html"
                       }
                   ]
+              },
+              {
+                  key: "JSON Schema",
+                  data: [
+                      {
+                      value: "Modbus JSON Schema",
+                      href: "modbus.schema.json"
+                      }
+                  ]
               }
             ]
         };

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -36,6 +36,15 @@
                       href: "../../../ontology/modbus.html"
                       }
                   ]
+              },
+              {
+                  key: "JSON Schema",
+                  data: [
+                      {
+                      value: "Modbus JSON Schema",
+                      href: "modbus.schema.json"
+                      }
+                  ]
               }
             ]
         };

--- a/bindings/protocols/template.schema.json
+++ b/bindings/protocols/template.schema.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "anyOf": [
+        {
+            "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"
+        }
+    ],
+    "definitions": {
+        "BINDINGNAMEForm": {
+            "type": "object",
+            "properties": {
+                "bindingPrefix:bindingVocabularyItem1": {"type": "string"},
+                "bindingPrefix:bindingVocabularyItem2": {"type": "number"},
+                "required": ["bindingPrefix:bindingVocabularyItem1"]
+            }
+        },
+        "affordance": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "forms": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/BINDINGNAMEForm"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "type": "object",
+    "properties": {
+        "@context": {
+            "type": "array",
+            "contains": {
+                "type": "object",
+                "properties": {
+                    "bindingPrefix": {
+                        "type": "string",
+                        "enum": [
+                            "BINDING CONTEXT"
+                        ]
+                    }
+                }
+            }
+        },
+        "properties": {
+            "$ref": "#/definitions/affordance"
+        },
+        "actions": {
+            "$ref": "#/definitions/affordance"
+        },
+        "events": {
+            "$ref": "#/definitions/affordance"
+        }
+    }
+}

--- a/index.html
+++ b/index.html
@@ -341,7 +341,11 @@
                         the mapping, the mapping SHOULD be bidirectional, i.e. it should be clear how to
                         do a <code>readproperty</code> operation with the given protocol and how an existing
                         implementation's endpoints can be mapped to a WoT operation should be also clear.
-                        
+                    </li>
+                    <li>
+                        <b>JSON Schema:</b> A JSON Schema to validate the forms of a TD using the Protocol Binding SHOULD be provided. This allows validation of the URI scheme and the vocabulary terms.
+                        The JSON Schema instance SHOULD follow the template provided in <a
+                        href="https://github.com/w3c/wot-binding-templates/blob/main/bindings/protocols/template.schema.json">the Binding Templates GitHub Repository.</a> 
                     </li>
                     <li>
                         <b>Specification:</b> The official specification document of the protocol SHOULD be

--- a/render.js
+++ b/render.js
@@ -30,7 +30,7 @@ sttl.connect(q => {
 });
 
 const ontologies = [
-    'ontology/coap.ttl',
+    // 'ontology/coap.ttl',
     'ontology/mqtt.ttl',
     'ontology/modbus.ttl'
 ];


### PR DESCRIPTION
fixes #205 

Note: Each commit can be viewed independently for all the different implemented features. 

In this PR, I have done the following:
- Add a requirement that a JSON Schema should be provided for the protocol bindings
- Create a JSON Schema template
- Add link to Modbus schema in the modbus document (@relu91)
- Fixed a bug in the render script that was asking for coap.ttl


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/pull/225.html" title="Last updated on Jan 25, 2023, 11:45 AM UTC (7fc8fbf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/225/a3e0636...7fc8fbf.html" title="Last updated on Jan 25, 2023, 11:45 AM UTC (7fc8fbf)">Diff</a>