### PR TITLE
Temporary Section Reorg - Part 3: Data Schemas

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,7 +522,7 @@
                     <h5>Data Schemas</h5>
 
                     <p>
-                        Data Schema as explained in [[WOT-THING-DESCRIPTION]] describes the structure of the messages, which are used together with media types.
+                        Data Schema, as explained in [[WOT-THING-DESCRIPTION]], describes the structure of the messages, which are used together with media types.
                         Even though it is largely inspired by JSON Schema [[json-schema]], it can be used for describing
                         other payload types such as [[XML]], string-encoded images, bit representations of integers, etc.
                         Data Schema SHOULD be used in addition to the media types.
@@ -530,6 +530,25 @@
                     <p>
                         Depending on the case, the structure of the messages can be anything from a simple number to
                         arrays or objects with multiple levels of nesting.
+                        Existing IoT Platforms and Standards have certain payload formats with variations on how the data is structured.
+                        As explained in [[WOT-THING-DESCRIPTION]], Data Schema can be used in a TD in one of the following places:
+                        <ul>
+                            <li><b>Property Affordances:</b> Each property affordance can contain terms for Data Schema
+                            and describe the property values when read, observed or written to.</li>
+                            <li><b>Action Affordances:</b> <code>input</code> and <code>output</code> keywords are used 
+                                to provide two different schemas when data is exchanged in both directions, such as in 
+                                the case of invoking an Action Affordance with input parameters and receiving status information.</li>
+                            <li><b>Event Affordances:</b> <code>data</code>, <code>dataResponse</code>, <code>subscription</code> 
+                                and <code>cancellation</code> are used to describe the payload when the event data
+                                is delivered by the Exposed Thing, the payload to reply with for event deliveries,
+                                 the payload needed to subscribe to the event and the payload needed to cancel receiving event
+                                data from the Exposed Thing, respectively.</li>
+                            <li><b>URI Variables:</b> In the Thing or Affordance level, <code>uriVariables</code> can
+                            describe the data that needs to be supplied inside the request URI as a string.</li>
+                        </ul>
+                    </p>
+                    <p>
+
                     </p>
                 </section>
             </section>
@@ -1221,36 +1240,6 @@
         
             <section id="payload-structure">
                 <h2>Payload Structure</h2>
-                <p>
-                    Payload Structure is determined by <code>DataSchema</code> elements of a Thing Description.
-                    DataSchema elements should be used by an instance of a <code>PropertyAffordance</code>,
-                    <code>input</code>/<code>output</code> of <code>ActionAffordance</code>,
-                    <code>data</code>/<code>subscription</code>/<code>cancellation</code> of an
-                    <code>EventAffordance</code> or by
-                    a <code>uriVariable</code> of the <code>InteractionAffordance</code>.
-                    As indicated in the [[WOT-THING-DESCRIPTION]], <code>DataSchema</code> Vocabulary is a subset of
-                    JSON Schema [[json-schema]]
-                </p>
-                <p>
-                    In the case of Action Affordances, the additional keywords <code>input</code> and
-                    <code>output</code> are used to provide two different schemas when data
-                    might be exchanged in both directions, such as in the case of invoking an Action Affordance
-                    with input parameters and receiving status information.
-                </p>
-                <p>
-                    In the case of Event Affordances, the additional keywords <code>data</code>,
-                    <code>subscription</code> and <code>cancellation</code> are used to describe the payload when the event data
-                    is delivered by the
-                    Exposed Thing, the payload needed to subscribe to the event and the payload needed to cancel receiving event
-                    data
-                    from the Exposed Thing, respectively.
-                </p>
-                <p>
-                    In addition to the example pattern in [[WOT-THING-DESCRIPTION]] of an object with name/value
-                    constructs or simple arrays, Protocol Bindings for existing standards
-                    may require nested arrays and objects, and some constant values to
-                    be specified.
-                </p>
         
                 <p>
                     Below are examples of different payloads and their corresponding <code>DataSchema</code>.

--- a/index.html
+++ b/index.html
@@ -549,7 +549,7 @@
                     </p>
                     <p>
                         Below is an example of a simple JSON object payload with the corresponding Data Schema. 
-                        Examples from various IoT Platforms and Standards can be found in the [[[#sec-payload-examples]]].
+                        Examples from various IoT Platforms and Standards can be found in [[[#sec-payload-examples]]].
                     </p>
                     <table>
                         <tbody>

--- a/index.html
+++ b/index.html
@@ -548,8 +548,42 @@
                         </ul>
                     </p>
                     <p>
-
+                        Below is an example of a simple JSON object payload with the corresponding Data Schema. 
+                        Examples from various IoT Platforms and Standards can be found in the appendice X.
                     </p>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td style="vertical-align: top; width: 50%">
+                                    <pre class="example" title="Simple JSON Object Payload">
+                                        {
+                                        "level": 50,
+                                        "time": 10
+                                        }
+                                    </pre>
+                                </td>
+                                <td style="vertical-align: top; width: 50%">
+                                    <pre class="example" title="DataSchema for Simple JSON Object Payload">
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "level": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "maximum": 255
+                                                },
+                                                "time": {
+                                                    "type": "integer",
+                                                    "minimum": 0,
+                                                    "maximum": 65535
+                                                }
+                                            }
+                                        }
+                                    </pre>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </section>
             </section>
             <section id="payload-bindings-table">
@@ -1243,47 +1277,7 @@
         
                 <p>
                     Below are examples of different payloads and their corresponding <code>DataSchema</code>.
-                </p>
-        
-                <p>
-                    For example, a simple payload structure may use a map:
-                </p>
-                <table>
-                    <tbody>
-                        <tr>
-                            <td style="vertical-align: top; width: 50%">
-                                <pre class="example" title="Simple JSON Object Payload">
-                                    {
-                                    "level": 50,
-                                    "time": 10
-                                    }
-                                </pre>
-                            </td>
-                            <td style="vertical-align: top; width: 50%">
-                                <pre class="example" title="DataSchema for Simple JSON Object Payload">
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "level": {
-                                                "@type": ["iot:LevelData"],
-                                                "type": "integer",
-                                                "minimum": 0,
-                                                "maximum": 255
-                                            },
-                                            "time": {
-                                                "@type": ["iot:TransitionTimeData"],
-                                                "type": "integer",
-                                                "minimum": 0,
-                                                "maximum": 65535
-                                            }
-                                        }
-                                    }
-                                </pre>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-        
+                </p>        
         
                 <p>
                     SenML [[RFC8428]] might use the following construct:

--- a/index.html
+++ b/index.html
@@ -1516,19 +1516,6 @@
                 </table>
         
             </section>
-        
-            <section id="data-types-constraints">
-                <h2>Data Types and value constraints</h2>
-                <p>
-                    Note that in Example 7 above, the values are floating point (<code>double</code>) while the other
-                    examples have integer values.
-                    In general, Consumers should follow the data schemas strictly, not generating anything not given in
-                    the WoT Thing Description, but should accept additional data from the Thing not given explicitly in
-                    the WoT Thing Description.
-                    This means that a Consumer sending the payload of the Example 7 should use floating points in the
-                    payload.
-                </p>
-            </section>
 
         </section>
 

--- a/index.html
+++ b/index.html
@@ -1093,8 +1093,8 @@
         <h2>Examples of Payloads and Data Schemas from IoT Platforms and Standards</h2>
 
         <p>
-            As an extension of [[[#payload-bindings-dataschema]]], this section collects examples of different payloads and their 
-            corresponding <code>DataSchema</code>.
+            As an extension of [[[#payload-bindings-dataschema]]], this section collects examples of different payloads 
+            and their corresponding <code>DataSchema</code>.
             These are from well-known IoT Platforms and Standards and aim to illustrate the various ways a payload can 
             look like and how one can describe it with a Data Schema.
         </p>        
@@ -1107,7 +1107,7 @@
             <tbody>
                 <tr>
                     <td style="vertical-align: top; width: 50%">
-                        <pre class="example" title="SenML Example">
+                        <pre class="example" title="SenML Payload Example">
                         [
                             {
                             "bn": "/example/light/"
@@ -1124,7 +1124,7 @@
                         </pre>
                     </td>
                     <td style="vertical-align: top; width: 50%">
-                        <pre class="example" title="DataSchema for SenML Payload">
+                        <pre class="example" title="Data Schema for SenML Payload Example">
                         {
                             "type": "array",
                             "items": [
@@ -1201,7 +1201,7 @@
                         </pre>
                     </td>
                     <td style="vertical-align: top; width: 50%">
-                        <pre class="example" title="DataSchema for OCF Batch Payload">
+                        <pre class="example" title="Data Schema for OCF Batch Payload Example">
                         {
                         "type": "array",
                         "items": [
@@ -1261,7 +1261,7 @@
             <tbody>
                 <tr>
                     <td style="vertical-align: top; width: 50%">
-                        <pre class="example" title="IPSO/LWM2M Example">
+                        <pre class="example" title="IPSO/LWM2M Payload Example">
                         {
                         "bn": "/3001/0/",
                         "e": [
@@ -1278,7 +1278,7 @@
                         </pre>
                     </td>
                     <td style="vertical-align: top; width: 50%">
-                        <pre class="example" title="DataSchema for IPSO/LWM2M Payload">
+                        <pre class="example" title="Data Schema for IPSO/LWM2M Payload Example">
                         {
                         "type": "object",
                         "properties": {

--- a/index.html
+++ b/index.html
@@ -522,10 +522,14 @@
                     <h5>Data Schemas</h5>
 
                     <p>
-                        Data Schema concept to describe the structure of the messages, which are used together with media types.
-                    Even though it is largely inspired by JSON Schema [[json-schema]], it can be used for describing
-                    other payload types such as [[XML]], string-encoded images, bit representations of integers, etc.
-                    Data Schema SHOULD be used in addition to the media types.
+                        Data Schema as explained in [[WOT-THING-DESCRIPTION]] describes the structure of the messages, which are used together with media types.
+                        Even though it is largely inspired by JSON Schema [[json-schema]], it can be used for describing
+                        other payload types such as [[XML]], string-encoded images, bit representations of integers, etc.
+                        Data Schema SHOULD be used in addition to the media types.
+                    </p>
+                    <p>
+                        Depending on the case, the structure of the messages can be anything from a simple number to
+                        arrays or objects with multiple levels of nesting.
                     </p>
                 </section>
             </section>

--- a/index.html
+++ b/index.html
@@ -549,7 +549,7 @@
                     </p>
                     <p>
                         Below is an example of a simple JSON object payload with the corresponding Data Schema. 
-                        Examples from various IoT Platforms and Standards can be found in the appendice X.
+                        Examples from various IoT Platforms and Standards can be found in the [[[#sec-payload-examples]]].
                     </p>
                     <table>
                         <tbody>
@@ -1089,6 +1089,247 @@
         
     </section>
 
+    <section id="sec-payload-examples">
+        <h2>Examples of Payloads and Data Schemas from IoT Platforms and Standards</h2>
+
+        <p>
+            As an extension of [[[#payload-bindings-dataschema]]], this section collects examples of different payloads and their 
+            corresponding <code>DataSchema</code>.
+            These are from well-known IoT Platforms and Standards and aim to illustrate the various ways a payload can 
+            look like and how one can describe it with a Data Schema.
+        </p>        
+
+        <p>
+            SenML [[RFC8428]] might use the following construct:
+        </p>
+
+        <table>
+            <tbody>
+                <tr>
+                    <td style="vertical-align: top; width: 50%">
+                        <pre class="example" title="SenML Example">
+                        [
+                            {
+                            "bn": "/example/light/"
+                            },
+                            {
+                            "n": "level",
+                            "v": 50
+                            },
+                            {
+                            "n": "time",
+                            "v": 10
+                            }
+                        ]
+                        </pre>
+                    </td>
+                    <td style="vertical-align: top; width: 50%">
+                        <pre class="example" title="DataSchema for SenML Payload">
+                        {
+                            "type": "array",
+                            "items": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                "bn": {
+                                    "type": "string",
+                                    "const": "example/light"
+                                }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                "n": {
+                                    "type": "string",
+                                    "const": "level"
+                                },
+                                "v": {
+                                    "@type": ["iot:LevelData"],
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 255
+                                }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                "n": {
+                                    "type": "string",
+                                    "const": "time"
+                                },
+                                "v": {
+                                    "@type": ["iot:TransitionTimeData"],
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 65535
+                                }
+                                }
+                            }
+                            ]
+                        }
+                        </pre>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+
+        <p>
+            A Batch Collection according to OCF[[OCF]] may be structured like this:
+        </p>
+
+        <table>
+            <tbody>
+                <tr>
+                    <td style="vertical-align: top; width: 50%">
+                        <pre class="example" title="OCF Batch Example">
+                        [
+                        {
+                            "href": "/example/light/level",
+                            "rep": {
+                            "dimmingSetting": 50
+                            }
+                        },
+                        {
+                            "href": "/example/light/time",
+                            "rep": {
+                            "rampTime": 10
+                            }
+                        }
+                        ]
+                        </pre>
+                    </td>
+                    <td style="vertical-align: top; width: 50%">
+                        <pre class="example" title="DataSchema for OCF Batch Payload">
+                        {
+                        "type": "array",
+                        "items": [
+                            {
+                            "type": "object",
+                            "properties": {
+                                "href": {
+                                "type": "string",
+                                "const": "/example/light/level"
+                                },
+                                "rep": {
+                                "type": "object",
+                                "properties": {
+                                    "dimmingSetting": {
+                                    "@type": ["iot:LevelData"],
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 255
+                                    }
+                                }
+                                }
+                            }
+                            },
+                            {
+                            "type": "object",
+                            "properties": {
+                                "href": {
+                                "type": "string",
+                                "const": "/example/light/time"
+                                },
+                                "rep": {
+                                "type": "object",
+                                "properties": {
+                                    "rampTime": {
+                                    "@type": ["iot:TransitionTimeData"],
+                                    "type":"integer",
+                                    "minimum": 0,
+                                    "maximum": 65535
+                                    }
+                                }
+                                }
+                            }
+                            }
+                        ]
+                        }
+                        </pre>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+
+        <p>
+            And an IPSO Smart Object on LWM2M [[LWM2M]] might look like the following:
+        </p>
+
+        <table>
+            <tbody>
+                <tr>
+                    <td style="vertical-align: top; width: 50%">
+                        <pre class="example" title="IPSO/LWM2M Example">
+                        {
+                        "bn": "/3001/0/",
+                        "e": [
+                            {
+                            "n": "5044",
+                            "v": 0.5
+                            },
+                            {
+                            "n": "5002",
+                            "v": 10.0
+                            }
+                        ]
+                        }
+                        </pre>
+                    </td>
+                    <td style="vertical-align: top; width: 50%">
+                        <pre class="example" title="DataSchema for IPSO/LWM2M Payload">
+                        {
+                        "type": "object",
+                        "properties": {
+                            "bn": {
+                            "type": "string",
+                            "const": "/3001/0/"
+                            },
+                            "e": {
+                            "type": "array",
+                            "items": [
+                                {
+                                "type": "object",
+                                "properties": {
+                                    "n": {
+                                    "type": "string",
+                                    "const": "5044"
+                                    },
+                                    "v": {
+                                    "@type": ["iot:LevelData"],
+                                    "type": "number",
+                                    "minimum": 0.0,
+                                    "maximum": 1.0
+                                    }
+                                }
+                                },
+                                {
+                                "type": "object",
+                                "Properties": {
+                                    "n": {
+                                    "type": "string",
+                                    "const": "5002"
+                                    },
+                                    "v": {
+                                    "@type": ["iot:TransitionTimeData"],
+                                    "type": "number",
+                                    "minimum": 0.0,
+                                    "maximum": 6553.5
+                                    }
+                                }
+                                }
+                            ]
+                            }
+                        }
+                        }
+                        </pre>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+
+    </section>
     <section id="sec-temp">
         <h2>Temporary Sections</h2>
 
@@ -1263,254 +1504,6 @@
                         <code>wot.example.com</code> using the default MQTT port."</i>
                 </p>
             </section>
-        </section>
-
-        <section id="sec-data-schema">
-            <h2>Data Schema</h2>
-            <p>
-                A data schema describes the payload structure and included
-                data items that are passed between the Consumer and the Thing during interactions.
-            </p>
-        
-            <section id="payload-structure">
-                <h2>Payload Structure</h2>
-        
-                <p>
-                    Below are examples of different payloads and their corresponding <code>DataSchema</code>.
-                </p>        
-        
-                <p>
-                    SenML [[RFC8428]] might use the following construct:
-                </p>
-        
-                <table>
-                    <tbody>
-                        <tr>
-                            <td style="vertical-align: top; width: 50%">
-                                <pre class="example" title="SenML Example">
-                                [
-                                    {
-                                    "bn": "/example/light/"
-                                    },
-                                    {
-                                    "n": "level",
-                                    "v": 50
-                                    },
-                                    {
-                                    "n": "time",
-                                    "v": 10
-                                    }
-                                ]
-                                </pre>
-                            </td>
-                            <td style="vertical-align: top; width: 50%">
-                                <pre class="example" title="DataSchema for SenML Payload">
-                                {
-                                    "type": "array",
-                                    "items": [
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                        "bn": {
-                                            "type": "string",
-                                            "const": "example/light"
-                                        }
-                                        }
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                        "n": {
-                                            "type": "string",
-                                            "const": "level"
-                                        },
-                                        "v": {
-                                            "@type": ["iot:LevelData"],
-                                            "type": "integer",
-                                            "minimum": 0,
-                                            "maximum": 255
-                                        }
-                                        }
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                        "n": {
-                                            "type": "string",
-                                            "const": "time"
-                                        },
-                                        "v": {
-                                            "@type": ["iot:TransitionTimeData"],
-                                            "type": "integer",
-                                            "minimum": 0,
-                                            "maximum": 65535
-                                        }
-                                        }
-                                    }
-                                    ]
-                                }
-                                </pre>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-        
-                <p>
-                    A Batch Collection according to OCF[[OCF]] may be structured like this:
-                </p>
-        
-                <table>
-                    <tbody>
-                        <tr>
-                            <td style="vertical-align: top; width: 50%">
-                                <pre class="example" title="OCF Batch Example">
-                                [
-                                {
-                                    "href": "/example/light/level",
-                                    "rep": {
-                                    "dimmingSetting": 50
-                                    }
-                                },
-                                {
-                                    "href": "/example/light/time",
-                                    "rep": {
-                                    "rampTime": 10
-                                    }
-                                }
-                                ]
-                                </pre>
-                            </td>
-                            <td style="vertical-align: top; width: 50%">
-                                <pre class="example" title="DataSchema for OCF Batch Payload">
-                                {
-                                "type": "array",
-                                "items": [
-                                    {
-                                    "type": "object",
-                                    "properties": {
-                                        "href": {
-                                        "type": "string",
-                                        "const": "/example/light/level"
-                                        },
-                                        "rep": {
-                                        "type": "object",
-                                        "properties": {
-                                            "dimmingSetting": {
-                                            "@type": ["iot:LevelData"],
-                                            "type": "integer",
-                                            "minimum": 0,
-                                            "maximum": 255
-                                            }
-                                        }
-                                        }
-                                    }
-                                    },
-                                    {
-                                    "type": "object",
-                                    "properties": {
-                                        "href": {
-                                        "type": "string",
-                                        "const": "/example/light/time"
-                                        },
-                                        "rep": {
-                                        "type": "object",
-                                        "properties": {
-                                            "rampTime": {
-                                            "@type": ["iot:TransitionTimeData"],
-                                            "type":"integer",
-                                            "minimum": 0,
-                                            "maximum": 65535
-                                            }
-                                        }
-                                        }
-                                    }
-                                    }
-                                ]
-                                }
-                                </pre>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-        
-                <p>
-                    And an IPSO Smart Object on LWM2M [[LWM2M]] might look like the following:
-                </p>
-        
-                <table>
-                    <tbody>
-                        <tr>
-                            <td style="vertical-align: top; width: 50%">
-                                <pre class="example" title="IPSO/LWM2M Example">
-                                {
-                                "bn": "/3001/0/",
-                                "e": [
-                                    {
-                                    "n": "5044",
-                                    "v": 0.5
-                                    },
-                                    {
-                                    "n": "5002",
-                                    "v": 10.0
-                                    }
-                                ]
-                                }
-                                </pre>
-                            </td>
-                            <td style="vertical-align: top; width: 50%">
-                                <pre class="example" title="DataSchema for IPSO/LWM2M Payload">
-                                {
-                                "type": "object",
-                                "properties": {
-                                    "bn": {
-                                    "type": "string",
-                                    "const": "/3001/0/"
-                                    },
-                                    "e": {
-                                    "type": "array",
-                                    "items": [
-                                        {
-                                        "type": "object",
-                                        "properties": {
-                                            "n": {
-                                            "type": "string",
-                                            "const": "5044"
-                                            },
-                                            "v": {
-                                            "@type": ["iot:LevelData"],
-                                            "type": "number",
-                                            "minimum": 0.0,
-                                            "maximum": 1.0
-                                            }
-                                        }
-                                        },
-                                        {
-                                        "type": "object",
-                                        "Properties": {
-                                            "n": {
-                                            "type": "string",
-                                            "const": "5002"
-                                            },
-                                            "v": {
-                                            "@type": ["iot:TransitionTimeData"],
-                                            "type": "number",
-                                            "minimum": 0.0,
-                                            "maximum": 6553.5
-                                            }
-                                        }
-                                        }
-                                    ]
-                                    }
-                                }
-                                }
-                                </pre>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-        
-            </section>
-
         </section>
 
     <script id="dstimer" language="javascript">


### PR DESCRIPTION
Should be merged after #228 

In this PR, I am reorganizing the examples of data schemas. More specifically:
- The explanation on where a data schema can exist is moving up from the appendix
- Examples of payloads for IoT Standards and Platform gets moved into a new appendix dedicated for it and not name "temporary"
- Removing an assertive sentence since it is actually in the TD spec


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/pull/236.html" title="Last updated on Feb 8, 2023, 4:43 PM UTC (e85eacc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/236/57216b3...e85eacc.html" title="Last updated on Feb 8, 2023, 4:43 PM UTC (e85eacc)">Diff</a>