### PR TITLE
Add JSON Schema for HTTP

### DIFF
--- a/bindings/protocols/http/http.schema.json
+++ b/bindings/protocols/http/http.schema.json
@@ -52,6 +52,9 @@
         },
         "events": {
             "$ref": "#/definitions/affordance"
+        },
+        "@context": {
+            "$comment":"When the HTTP vocabulary is not part of the TD vocabulary anymore, requirements on the context usage should be added"
         }
     }
 }

--- a/bindings/protocols/http/http.schema.json
+++ b/bindings/protocols/http/http.schema.json
@@ -44,20 +44,6 @@
     },
     "type": "object",
     "properties": {
-        "@context": {
-            "type": "array",
-            "contains": {
-                "type": "object",
-                "properties": {
-                    "htv": {
-                        "type": "string",
-                        "enum": [
-                            "http://www.w3.org/2011/http#"
-                        ]
-                    }
-                }
-            }
-        },
         "properties": {
             "$ref": "#/definitions/affordance"
         },

--- a/bindings/protocols/http/http.schema.json
+++ b/bindings/protocols/http/http.schema.json
@@ -1,0 +1,71 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "anyOf": [
+        {
+            "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"
+        }
+    ],
+    "definitions": {
+        "HttpForm": {
+            "type": "object",
+            "properties": {
+                "htv:methodName": {"type": "string", "examples":["GET","PUT","POST","DELETE","PATCH"]},
+                "htv:headers": {
+                    "type": "array",
+                    "items":{
+                        "type":"object",
+                        "properties":{
+                            "htv:fieldName":{
+                                "type": "string", "examples":["Accept","Transfer-Encoding"]
+                            },
+                            "htv:fieldValue":{
+                                "type": "string"
+                            }
+                        },
+                        "required":["htv:fieldName"]
+                    }
+                }
+            }
+        },
+        "affordance": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "forms": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/HttpForm"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "type": "object",
+    "properties": {
+        "@context": {
+            "type": "array",
+            "contains": {
+                "type": "object",
+                "properties": {
+                    "htv": {
+                        "type": "string",
+                        "enum": [
+                            "http://www.w3.org/2011/http#"
+                        ]
+                    }
+                }
+            }
+        },
+        "properties": {
+            "$ref": "#/definitions/affordance"
+        },
+        "actions": {
+            "$ref": "#/definitions/affordance"
+        },
+        "events": {
+            "$ref": "#/definitions/affordance"
+        }
+    }
+}

--- a/bindings/protocols/http/index.html
+++ b/bindings/protocols/http/index.html
@@ -41,6 +41,15 @@
                       href: "https://www.w3.org/TR/HTTP-in-RDF10/"
                       }
                   ]
+              },
+              {
+                  key: "JSON Schema",
+                  data: [
+                      {
+                      value: "HTTP JSON Schema",
+                      href: "http.schema.json"
+                      }
+                  ]
               }
             ]
         };


### PR DESCRIPTION
fixes #229 

There is one annoying issue here though. The HTTP context is actually embedded in the TD one. So if we make it mandatory to have the `"htv":"http://www.w3.org/2011/http#"` TDs that do not put it but still use the HTTP terms will be invalid but they are actually ok. Any opinions?