### PR TITLE
feat(coap): add CoAP JSON-LD @context

### DIFF
--- a/bindings/protocols/coap/context.jsonld
+++ b/bindings/protocols/coap/context.jsonld
@@ -1,0 +1,43 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "cov": "https://www.w3.org/2019/wot/cov#",
+        "method": {
+            "@id": "cov:hasMethod",
+            "@type": "xsd:string"
+        },
+        "BlockWiseTransferParameters": {
+            "@id": "cov:BlockWiseTransferParameters"
+        },
+        "blockwise": {
+            "@id": "cov:hasBlockwise",
+            "@type": "@id",
+            "@container": "@index"
+        },
+        "qblockwise": {
+            "@id": "cov:hasQBlockwise",
+            "@type": "@id",
+            "@container": "@index"
+        },
+        "block2SZX": {
+            "@id": "cov:hasblock2SZX",
+            "@type": "xsd:unsignedShort"
+        },
+        "block1SZX": {
+            "@id": "cov:hasblock1SZX",
+            "@type": "xsd:unsignedShort"
+        },
+        "accept": {
+            "@id": "cov:hasAccept",
+            "@type": "xsd:unsignedShort"
+        },
+        "contentFormat": {
+            "@id": "cov:hasContentFormat",
+            "@type": "xsd:unsignedShort"
+        },
+        "hopLimit": {
+            "@id": "cov:hasHopLimit",
+            "@type": "xsd:unsignedByte"
+        }
+    }
+}


### PR DESCRIPTION
This PR contains a first attempt at creating a JSON-LD @context file for the CoAP Vocabulary. It is honestly mostly the result of some trial-and-error using the JSON-LD playground, so I am not really sure if the @context is usable already 😅 I was also a bit unsure whether the @context for a Binding Document is a result or an input of the rendering process. So these points need to be taken into account when reviewing the PR.

I hope the file can still serve as a starting point for further discussion and for working out a @context file that is actually usable :) I am looking forward to your feedback!