### PR TITLE
Refactor render script

### DIFF
--- a/render.js
+++ b/render.js
@@ -1,86 +1,104 @@
-let fs = require('fs');
-let sttl = require('sttl');
-let urdf = require('urdf');
-const toRDf = require('./toRdf.js').context
+const fs = require('fs');
+const sttl = require('sttl');
+const urdf = require('urdf');
+const toRDf = require('./toRdf.js').context;
 
 const tpl = fs.readFileSync('ontology/templates.rq', 'utf-8');
 
 sttl.register(tpl);
-sttl.connect(q => {
-    return urdf.query(q)
-        .then(b => {
-            const bindings = b.reduce((accumulator, value) => {
-                // Flat bindings that have list variables
-                // Note: this method only works for one list variable per binding
-                const found = Object.keys(value).find(k => value[k].type === "list")
-                if (found) {
-                    value[found].value.forEach(listElement => {
-                        const newBinding = Object.assign({}, value)
-                        newBinding[found] = listElement
-                        accumulator.push(newBinding);
-                    });
-                } else {
-                    accumulator.push(value)
-                }
-                return accumulator
-            }, []);
-
-            return { results: { bindings } }
-        });
+sttl.connect(async (query) => {
+    const graph = await urdf.query(query);
+    const bindings = graph.reduce((accumulator, value) => {
+        // Flat bindings that have list variables
+        // Note: this method only works for one list variable per binding
+        const found = Object.keys(value).find((k) => value[k].type === 'list');
+        if (found) {
+            value[found].value.forEach((listElement) => {
+                const newBinding = Object.assign({}, value);
+                newBinding[found] = listElement;
+                accumulator.push(newBinding);
+            });
+        } else {
+            accumulator.push(value);
+        }
+        return accumulator;
+    }, []);
+    return { results: { bindings } };
 });
 
 const ontologies = [
     // 'ontology/coap.ttl',
     'ontology/mqtt.ttl',
-    'ontology/modbus.ttl'
+    'ontology/modbus.ttl',
 ];
 
-
 console.log("Rendering ontology documentation...");
-const promiseChain = ontologies.reduce((p, src) => {
-    const ontologyFile = src
-    const templateURI = 'http://w3c.github.io/wot-binding-templates/ontology#main'
-    return p.then( _ => render(ontologyFile,templateURI,ontologyFile.replace('.ttl', '.html'))).then(() => urdf.clear())
+const promiseChain = ontologies.reduce(async (previousPromise, ontologyFile) => {
+    const templateURI =
+        'http://w3c.github.io/wot-binding-templates/ontology#main';
+    await previousPromise;
+    await render(
+        ontologyFile,
+        templateURI,
+        ontologyFile.replace('.ttl', '.html')
+    );
+    await urdf.clear();
 }, Promise.resolve());
 
 
 console.log("Rendering WoT binding documentation...");
 
 const mappings = [
-    ['bindings/protocols/modbus/mapping.ttl', 'ontology/modbus.ttl', 'http://w3c.github.io/wot-binding-templates/mappings#modbus','bindings/protocols/modbus/context.jsonld'],
-    ['bindings/protocols/mqtt/mapping.ttl', 'ontology/mqtt.ttl', 'http://w3c.github.io/wot-binding-templates/mappings#mqtt', 'bindings/protocols/mqtt/context.jsonld']
+    {
+        ontologyFile: 'bindings/protocols/modbus/mapping.ttl',
+        baseOntologyFile: 'ontology/modbus.ttl',
+        templateURI:
+            'http://w3c.github.io/wot-binding-templates/mappings#modbus',
+        contextFile: 'bindings/protocols/modbus/context.jsonld',
+    },
+    {
+        ontologyFile: 'bindings/protocols/mqtt/mapping.ttl',
+        baseOntologyFile: 'ontology/mqtt.ttl',
+        templateURI: 'http://w3c.github.io/wot-binding-templates/mappings#mqtt',
+        contextFile: 'bindings/protocols/mqtt/context.jsonld',
+    },
 ];
 
-
-const modbusTemplate = fs.readFileSync('bindings/protocols/modbus/template.sparql', 'utf-8');
-const mqttTemplate = fs.readFileSync('bindings/protocols/mqtt/template.sparql', 'utf-8');
+const modbusTemplate = fs.readFileSync(
+    'bindings/protocols/modbus/template.sparql',
+    'utf-8'
+);
+const mqttTemplate = fs.readFileSync(
+    'bindings/protocols/mqtt/template.sparql',
+    'utf-8'
+);
 sttl.register(modbusTemplate);
 sttl.register(mqttTemplate);
 
-mappings.reduce((p, src) => {
-    const ontologyFile = src[0]
-    const baseOntologyFile = src[1]
-    const templateURI = src[2]
-    const contextFile = src[3]
-    let base = fs.readFileSync( baseOntologyFile, 'UTF-8');
-    return p.then( _ => urdf.load(base,{ format: 'text/turtle' }))
-        .then(() => {
-            const jsonld = fs.readFileSync(contextFile,'utf8');
-            const result = toRDf(JSON.parse(jsonld));
-            return urdf.load(result)
-        })
-        .then( _ => render(ontologyFile,templateURI,ontologyFile.replace('mapping.ttl', 'index.html')))
-        .then(() => urdf.clear());
-},promiseChain);
+mappings.reduce(async (previousPromise, mapping) => {
+    const { ontologyFile, baseOntologyFile, templateURI, contextFile } = mapping;
+    const base = fs.readFileSync(baseOntologyFile, 'UTF-8');
+    await previousPromise;
+    await urdf.load(base, { format: 'text/turtle' });
+    const jsonld = fs.readFileSync(contextFile, 'utf8');
+    const result = toRDf(JSON.parse(jsonld));
+    await urdf.load(result);
+    await render(
+        ontologyFile,
+        templateURI,
+        ontologyFile.replace('mapping.ttl', 'index.html')
+    );
+    await urdf.clear();
+}, promiseChain);
 
-function render(ontologyFile,templateURI,output) {
-    let ttl = fs.readFileSync(ontologyFile, 'UTF-8');
-    return Promise.resolve()
-    .then(() => urdf.load(ttl, { format: 'text/turtle' }))
-    .then(() => sttl.callTemplate(templateURI, ttl))
-    .then(html => fs.writeFileSync(output, html))
-    .then(_ => console.log("File ",output,"generated"))
-    .catch((e) => {
+async function render(ontologyFile, templateURI, output) {
+    const ttl = fs.readFileSync(ontologyFile, 'UTF-8');
+    try {
+        await urdf.load(ttl, { format: 'text/turtle' });
+        const html = await sttl.callTemplate(templateURI, ttl);
+        fs.writeFileSync(output, html);
+        console.log('File ', output, 'generated');
+    } catch (e) {
         console.error('Error while rendering ' + ontologyFile + ': ' + e);
-    });
+    }
 }


### PR DESCRIPTION
As mentioned in https://github.com/w3c/wot-binding-templates/pull/240#issuecomment-1423365415, this PR makes a proposal for refactoring the render script using async-await and object destructuring, which should make the code a bit more readable.

I could not get rid of the promiseChain, which I also found a bit confusing to read, without breaking the script, but I still think it would also be a good candidate for future refactoring.