### PR TITLE
Use `dct:creator` instead of `dct:author` in ontologies

### DIFF
--- a/ontology/modbus.template.rq
+++ b/ontology/modbus.template.rq
@@ -69,7 +69,7 @@ template :editor(?o) {
     "companyURL:" ?url
     "}" ; separator = ","
 } where {
-    { ?o dct:author ?ed } union { ?o dct:contributor ?ed }
+    { ?o dct:creator ?ed } union { ?o dct:contributor ?ed }
     ?ed schema:name ?name ; schema:affiliation ?org .
     ?org schema:name ?company ; schema:url ?url .
 }

--- a/ontology/modbus.ttl
+++ b/ontology/modbus.ttl
@@ -12,7 +12,7 @@
 @base <https://www.w3.org/2019/wot/modbus> .
 
 <https://www.w3.org/2019/wot/modbus> rdf:type owl:Ontology ;
-                                      dct:author "Jakob Müller https://github.com/Drukob" ;
+                                      dct:creator "Jakob Müller https://github.com/Drukob" ;
                                       dct:contributor "Cristiano Aguzzi https://github.com/relu91" ,
                                                       "Elisa Riforgiato https://github.com/elithkob" ,
                                                       "Jakob Müller https://github.com/Drukob" ,

--- a/ontology/mqtt.ttl
+++ b/ontology/mqtt.ttl
@@ -11,13 +11,13 @@
 
 
 <https://www.w3.org/2019/wot/mqtt> rdf:type owl:Ontology ;
-                                    dct:author [ rdf:type schema:Person ;
-                                                 schema:affiliation [ rdf:type schema:Organization ;
-                                                                      schema:name "Invited Expert" ;
-                                                                      schema:url "https://github.com/mjkoster/"
-                                                                    ] ;
-                                                 schema:name "Michael Koster"
-                                               ] ;
+                                    dct:creator [ rdf:type schema:Person ;
+                                                  schema:affiliation [ rdf:type schema:Organization ;
+                                                                       schema:name "Invited Expert" ;
+                                                                       schema:url "https://github.com/mjkoster/"
+                                                                     ] ;
+                                                  schema:name "Michael Koster"
+                                                ] ;
                                     dct:contributor <https://www.vcharpenay.link/#me> ,
                                                     [ rdf:type schema:Person ;
                                                       schema:affiliation _:genid4 ;

--- a/ontology/templates.rq
+++ b/ontology/templates.rq
@@ -68,7 +68,7 @@ template :editor(?o) {
     "companyURL:" ?url
     "}" ; separator = ","
 } where {
-    { ?o dct:author ?ed } union { ?o dct:contributor ?ed }
+    { ?o dct:creator ?ed } union { ?o dct:contributor ?ed }
     ?ed schema:name ?name ; schema:affiliation ?org .
     ?org schema:name ?company ; schema:url ?url .
 }


### PR DESCRIPTION
@ektrah noticed in https://github.com/w3c/wot-binding-templates/pull/246#discussion_r1129979924 that the term `author` that is currently being used to identify the authors of an ontology does not actually exist in the [DCMI Metadata Terms](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/). However, the term `creator` can be used instead.

This PR resolves the issue by simply replacing `dct:author` with `dct:creator`, leaving the resulting rendered ontologies unchanged.