### PR TITLE
Update ReSpec in ontology template

### DIFF
--- a/ontology/modbus.html
+++ b/ontology/modbus.html
@@ -3,7 +3,7 @@
 <html>
     <head>
     <meta charset='utf-8'>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove' defer></script>
     <script class='remove'>
         var respecConfig = {
             specStatus: "ED",
@@ -28,7 +28,7 @@
             <h2>Introduction</h2>
 
             <p>
-                To use in TD forms. 
+                To use in TD forms.
             </p>
         </section>
 

--- a/ontology/modbus.template.rq
+++ b/ontology/modbus.template.rq
@@ -6,8 +6,8 @@ prefix schema: <http://schema.org/>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix vann: <http://purl.org/vocab/vann/>
 prefix dct: <http://purl.org/dc/terms/>
-prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
-prefix binding: <https://www.w3.org/2019/wot/binding#> 
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix binding: <https://www.w3.org/2019/wot/binding#>
 prefix : <http://w3c.github.io/wot-binding-templates/ontology#>
 
 template :modbus(?ns) {
@@ -17,7 +17,7 @@ template :modbus(?ns) {
 <html>
     <head>
     <meta charset='utf-8'>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove' defer></script>
     <script class='remove'>
         var respecConfig = {
             specStatus: "ED",

--- a/ontology/mqtt.html
+++ b/ontology/mqtt.html
@@ -3,7 +3,7 @@
 <html>
     <head>
     <meta charset='utf-8'>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove' defer></script>
     <script class='remove'>
         var respecConfig = {
             specStatus: "ED",
@@ -28,7 +28,7 @@
             <h2>Introduction</h2>
 
             <p>
-                To use in TD forms. 
+                To use in TD forms.
             </p>
         </section>
 

--- a/ontology/templates.rq
+++ b/ontology/templates.rq
@@ -15,7 +15,7 @@ template :main(?ns) {
 <html>
     <head>
     <meta charset='utf-8'>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove' defer></script>
     <script class='remove'>
         var respecConfig = {
             specStatus: "ED",
@@ -40,7 +40,7 @@ template :main(?ns) {
             <h2>Introduction</h2>
 
             <p>
-                To use in TD forms. 
+                To use in TD forms.
             </p>
         </section>
 


### PR DESCRIPTION
This PR deals with a minor ReSpec warning in the ontologies that advises to migrate from `respec-w3c-common` to `respec-w3c`, by updating `templates.rq` and generating the rendered ontology versions.