### PR TITLE
Remove GitHub io links for specs like Arch and TD

### DIFF
--- a/index.html
+++ b/index.html
@@ -629,7 +629,7 @@
                         In this specific case, the forms describe that reading this property with <code>http</code> or
                         <code>coap</code> result in different content types.
                         For structured media types, a Data Schema is generally provided in the affordance level as
-                        explained in [[[#payload-bindings-dataschema]]] and <a href="https://w3c.github.io/wot-thing-description/#sec-data-schema-vocabulary-definition">
+                        explained in [[[#payload-bindings-dataschema]]] and <a data-cite="WOT-THING-DESCRIPTION#sec-data-schema-vocabulary-definition">
                         in the Data Schema section of the TD specification</a>.
                         However, for unstructured data such as images and videos, a Data Schema is typically not available.
                     </p>

--- a/index.html
+++ b/index.html
@@ -234,7 +234,7 @@
             <dfn class="lint-ignore">Vocabulary</dfn>,
             <dfn class="lint-ignore">WoT Interface</dfn>,
             <dfn class="lint-ignore">WoT Runtime</dfn>,
-            etc. is defined in <a href="https://w3c.github.io/wot-architecture/#terminology">Section 3</a>
+            etc. is defined in <a data-cite="WOT-ARCHITECTURE#terminology">Section 3</a>
             of the WoT Architecture specification [[WOT-ARCHITECTURE]].
         </p>
 
@@ -1254,32 +1254,32 @@
 
         <p>
             The <a
-                href="https://w3c.github.io/wot-architecture/#dfn-wot-thing-description">WoT
+                data-cite="WOT-ARCHITECTURE#dfn-wot-thing-description">WoT
                 Thing Description</a> must be used together with integrity protection mechanisms and access control
             policies.
             Users must ensure that no sensitive information is included in the <a
-                href="https://w3c.github.io/wot-architecture/#dfn-td">TDs</a>
+                data-cite="WOT-ARCHITECTURE/#dfn-td">TDs</a>
             themselves.
         </p>
 
         <p>
             The <a
-                href="https://w3c.github.io/wot-architecture/#dfn-wot-binding-templates">WoT
+                data-cite="WOT-ARCHITECTURE#dfn-wot-binding-templates">WoT
                 Binding Templates</a> must correctly cover the security mechanisms employed by the underlying <a
-                href="https://w3c.github.io/wot-architecture/#dfn-iot-platform">IoT
+                data-cite="WOT-ARCHITECTURE#dfn-iot-platform">IoT
                 platform</a>.
             Due to the automation of network interactions necessary in the IoT, operators need to ensure that <a
-                href="https://w3c.github.io/wot-architecture/#dfn-thing">Things</a>
+                data-cite="WOT-ARCHITECTURE#dfn-thing">Things</a>
             are exposed and consumed in a way that is compliant with their security policies.
         </p>
 
         <p>
-            The <a href="https://w3c.github.io/wot-architecture/#dfn-wot-runtime">
+            The <a data-cite="WOT-ARCHITECTURE#dfn-wot-runtime">
             WoT Runtime</a> implementation for the
-            <a href="https://w3c.github.io/wot-architecture/#dfn-wot-scripting-api">WoT
+            <a data-cite="WOT-ARCHITECTURE#dfn-wot-scripting-api">WoT
             Scripting API</a> must have mechanisms to prevent malicious access to the system and isolate scripts in
             multi-tenant <a
-            href="https://w3c.github.io/wot-architecture/#dfn-servient">Servients</a>.
+            data-cite="WOT-ARCHITECTURE#dfn-servient">Servients</a>.
         </p>
 
     </section>


### PR DESCRIPTION
I think we should use bib reference (with fragment identifier) instead 

Note: I think we should **not** link to github.io but instead to the published version of a document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-binding-templates/pull/273.html" title="Last updated on Mar 23, 2023, 9:00 AM UTC (fa11a51)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/273/c314cbd...danielpeintner:fa11a51.html" title="Last updated on Mar 23, 2023, 9:00 AM UTC (fa11a51)">Diff</a>