### PR TITLE
fix: move sotd sections before the introductions

### DIFF
--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -74,6 +74,11 @@
             Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior.
         </p>
     </section>
+    <section id='sotd'>
+        <p>
+            <em>This document is a work in progress</em>
+        </p>
+    </section>
     <section id='introduction'>
         <h2>Introduction</h2>
         <p>
@@ -100,11 +105,6 @@
         <p>
             A JSON Schema [[?JSON-SCHEMA]] to validate Thing Description instances
             containing CoAP Binding is provided in the <a href="coap.schema.json">GitHub repository</a>.
-        </p>
-    </section>
-    <section id='sotd'>
-        <p>
-            <em>This document is a work in progress</em>
         </p>
     </section>
     <section id="overview">

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -74,6 +74,11 @@
             Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior.
         </p>
     </section>
+    <section id='sotd'>
+        <p>
+            <em>This document is a work in progress</em>
+        </p>
+    </section>
     <section id='introduction'>
         <h2>Introduction</h2>
         <p>
@@ -100,11 +105,6 @@
         <p>
             A JSON Schema [[?JSON-SCHEMA]] to validate Thing Description instances
             containing CoAP Binding is provided in the <a href="coap.schema.json">GitHub repository</a>.
-        </p>
-    </section>
-    <section id='sotd'>
-        <p>
-            <em>This document is a work in progress</em>
         </p>
     </section>
     <section id="overview">

--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -67,6 +67,11 @@
             Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
         </p>
     </section>
+    <section id='sotd'>
+        <p>
+            <em>This document is a work in progress</em>
+        </p>
+    </section>
     <section id='introduction'>
         <h2>Introduction</h2>
         <p>
@@ -87,11 +92,6 @@
             In particular, the document explain how to create valid URLs and Forms for the different operations that the Modbus protocol can perform. 
             Developers are encouraged to use this document as an implementation guidelines and as a reference for the creation of their own binding implementations. 
             The following sections will cover the URL format, the Vocabulary and a list of Form examples. 
-        </p>
-    </section>
-    <section id='sotd'>
-        <p>
-            <em>This document is a work in progress</em>
         </p>
     </section>
     <section id="url">

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -67,6 +67,11 @@
             Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
         </p>
     </section>
+    <section id='sotd'>
+        <p>
+            <em>This document is a work in progress</em>
+        </p>
+    </section>
     <section id='introduction'>
         <h2>Introduction</h2>
         <p>
@@ -87,11 +92,6 @@
             In particular, the document explain how to create valid URLs and Forms for the different operations that the Modbus protocol can perform. 
             Developers are encouraged to use this document as an implementation guidelines and as a reference for the creation of their own binding implementations. 
             The following sections will cover the URL format, the Vocabulary and a list of Form examples. 
-        </p>
-    </section>
-    <section id='sotd'>
-        <p>
-            <em>This document is a work in progress</em>
         </p>
     </section>
     <section id="url">

--- a/bindings/protocols/mqtt/index.html
+++ b/bindings/protocols/mqtt/index.html
@@ -104,6 +104,11 @@
             Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
         </p>
     </section>
+    <section id='sotd'>
+        <p>
+            <em>This document is a work in progress</em>
+        </p>
+    </section>
     <section id='introduction'>
         <h2>Introduction</h2>
         <p>
@@ -136,11 +141,6 @@
             containing MQTT Binding is provided in the <a href="mqtt.schema.json">GitHub repository</a>.
         </p>
         
-    </section>
-    <section id='sotd'>
-        <p>
-            <em>This document is a work in progress</em>
-        </p>
     </section>
     <section id="url">
       <h2>URL format</h2>

--- a/bindings/protocols/mqtt/index.template.html
+++ b/bindings/protocols/mqtt/index.template.html
@@ -104,6 +104,11 @@
             Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
         </p>
     </section>
+    <section id='sotd'>
+        <p>
+            <em>This document is a work in progress</em>
+        </p>
+    </section>
     <section id='introduction'>
         <h2>Introduction</h2>
         <p>
@@ -136,11 +141,6 @@
             containing MQTT Binding is provided in the <a href="mqtt.schema.json">GitHub repository</a>.
         </p>
         
-    </section>
-    <section id='sotd'>
-        <p>
-            <em>This document is a work in progress</em>
-        </p>
     </section>
     <section id="url">
       <h2>URL format</h2>


### PR DESCRIPTION
In the current version of the protocol binding documents, the unnumbered "State of This Document" sections come after the numbered introductions (which looks a bit strange in the table of contents). This PR applies a simple fix with a minor section reordering.