### PR TITLE
feat(coap): add conformance section

### DIFF
--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -92,6 +92,16 @@
             In particular, the document explain how to create valid Forms for the different operations that CoAP can perform.
         </p>
     </section>
+    <section id="conformance">
+        <p>
+            Forms of a Thing Description instance with CoAP Binding complies with this specification if it follows
+            the normative statements in <a href="#vocabulary"></a> and <a href="#mappings"></a>.
+        </p>
+        <p>
+            A JSON Schema [[?JSON-SCHEMA]] to validate Thing Description instances
+            containing CoAP Binding is provided in the <a href="coap.schema.json">GitHub repository</a>.
+        </p>
+    </section>
     <section id='sotd'>
         <p>
             <em>This document is a work in progress</em>

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -92,6 +92,16 @@
             In particular, the document explain how to create valid Forms for the different operations that CoAP can perform.
         </p>
     </section>
+    <section id="conformance">
+        <p>
+            Forms of a Thing Description instance with CoAP Binding complies with this specification if it follows
+            the normative statements in <a href="#vocabulary"></a> and <a href="#mappings"></a>.
+        </p>
+        <p>
+            A JSON Schema [[?JSON-SCHEMA]] to validate Thing Description instances
+            containing CoAP Binding is provided in the <a href="coap.schema.json">GitHub repository</a>.
+        </p>
+    </section>
     <section id='sotd'>
         <p>
             <em>This document is a work in progress</em>


### PR DESCRIPTION
Inspired by the MQTT Binding Document, this PR adds a conformance section to the CoAP document which would make it possible to use keywords like MUST or SHOULD to formulate (quasi-)normative statements.

I partly opened this PR to discuss if including such a section is actually possible for a binding document or if all statements must be strictly informative – if a conformance section cannot be included, then the existing documents (namely the MQTT binding) would require adjustments as well.