### PR TITLE
Add table numbering and captions

### DIFF
--- a/index.html
+++ b/index.html
@@ -430,7 +430,8 @@
                     In addition to these, additional terms for describing protocol options are typically added.
                 </p>
 
-                <table class="def" id="table-protocol-terms">
+                <table class="def numbered" id="table-protocol-terms">
+                    <caption>Terms specified by Protocol Binding Templates</caption>
                     <thead>
                         <tr>
                             <th>Vocabulary Term</th>
@@ -484,7 +485,8 @@
                 <p>
                     The table below summarizes the currently specified protocols in their respective <a>Binding Template Subspecification</a>.
                 </p>
-                <table class="def">
+                <table class="def numbered">
+                    <caption>Existing Protocol Binding Templates</caption>
                     <thead>
                         <tr>
                             <th>Abbreviation</th>
@@ -753,7 +755,8 @@
                     In addition to these, additional vocabulary terms can be added and restrictions to Data Schema terms can be placed.
                 </p>
 
-                <table class="def" id="table-payload-terms">
+                <table class="def numbered" id="table-payload-terms">
+                    <caption>Terms specified by Payload Binding Templates</caption>
                     <thead>
                         <tr>
                             <th>Term</th>
@@ -790,7 +793,8 @@
                 <h4>Existing Payload Binding Templates</h4>
                 The table below summarizes the currently specified payload binding templates.
 
-                <table class="def">
+                <table class="def numbered">
+                    <caption>Existing Platform Binding Templates</caption>
                     <thead>
                         <tr>
                             <th>Abbreviation</th>
@@ -872,7 +876,8 @@
             The table below summarizes the currently specified platform binding template <a>subspecification</a>s.
             </p>
 
-            <table class="def">
+            <table class="def numbered">
+                <caption>Existing Platform Binding Templates</caption>
                 <thead>
                     <tr>
                         <th>Name</th>


### PR DESCRIPTION
fixes #272 

@danielpeintner the problem was that in order to use `[[[#my-table-id]]]`, you have to use the new respec option (class numbered) and then also put a caption. Thus, I just did that in all tables.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/pull/277.html" title="Last updated on Mar 28, 2023, 9:46 PM UTC (512dbb4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/277/c314cbd...512dbb4.html" title="Last updated on Mar 28, 2023, 9:46 PM UTC (512dbb4)">Diff</a>