### PR TITLE
Add conformance section to Modbus binding documentation

### DIFF
--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -67,6 +67,16 @@
             Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
         </p>
     </section>
+    <section id="conformance">
+        <p>
+            Forms of a Thing Description instance with Modbus Binding complies with this specification if it follows
+            the normative statements in <a href="#vocabulary"></a> and <a href="#mappings"></a>.
+        </p>
+        <p>
+            A JSON Schema [[?JSON-SCHEMA]] to validate Thing Description instances
+            containing Modbus Binding is provided in the <a href="modbus.schema.json">GitHub repository</a>.
+        </p>
+    </section>
     <section id='introduction'>
         <h2>Introduction</h2>
         <p>

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -67,6 +67,16 @@
             Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior. 
         </p>
     </section>
+    <section id="conformance">
+        <p>
+            Forms of a Thing Description instance with Modbus Binding complies with this specification if it follows
+            the normative statements in <a href="#vocabulary"></a> and <a href="#mappings"></a>.
+        </p>
+        <p>
+            A JSON Schema [[?JSON-SCHEMA]] to validate Thing Description instances
+            containing Modbus Binding is provided in the <a href="modbus.schema.json">GitHub repository</a>.
+        </p>
+    </section>
     <section id='introduction'>
         <h2>Introduction</h2>
         <p>


### PR DESCRIPTION
I copied over the new conformance section. Fixes #278