### PR TITLE
Subprotocol improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,22 +442,27 @@
                     <h4>Subprotocols</h4>
 
                     <p>
+                        As defined in  [[WOT-ARCHITECTURE]], a subprotocol is an extension mechanism to a protocol.
+                        A subprotocol can require a sequence of protocol messages or a specific structure of message payloads,
+                        which can have its own semantics within that subprotocol.
                         The use of a subprotocol is expressed with the <code>subprotocol</code> field, as defined in
                         [[!WOT-THING-DESCRIPTION]].
                         It can be used in a form instance to indicate the use of one of these protocols, for example long polling with its
                         special use of HTTP:
                     <pre class="example" title="Subprotocol usage for subscribing events">
-                                            {
-                                                "op": "subscribeevent",
-                                                "href": "https://mylamp.example.com/overheating",
-                                                "subprotocol": "longpoll"
-                                            }
-                                        </pre>
+                        {
+                            "op": "subscribeevent",
+                            "href": "https://mylamp.example.com/overheating",
+                            "subprotocol": "longpoll"
+                        }
+                    </pre>
                     </p>
                     
                     <p>
                         The values that the <code>subprotocol</code> term can take is not constrained by the [[!WOT-THING-DESCRIPTION]]
-                        since different protocols can have different Subprotocols.
+                        since different protocols can have different subprotocols.
+                        Correspondingly, subprotocols are linked to the protocol they are extending and should be understood together with 
+                        the protocol indicated in <code>href</code> of the forms (or the <code>base</code>).
                         For WebSockets, the IANA-registered Websocket Subprotocols [[iana-web-socket-registry]] may be used.
                         For CoAP, <code>"subprotocol":"cov:observe"</code> can be used to describe asynchronous observation
                         operations as defined by [[RFC6741]].

--- a/index.html
+++ b/index.html
@@ -438,34 +438,45 @@
                      (<code>longpoll</code>), WebSub [[WebSub]] (<code>websub</code>) and Server-Sent Events [[eventsource]] (<code>sse</code>).
                 </p>
 
-                <p>
-                    The use of a subprotocol is expressed with the <code>subprotocol</code> field, as defined in [[!WOT-THING-DESCRIPTION]].
-                    It can be used in a form instance to indicate the use of one of these protocols, for example long polling with its special use of HTTP:
+                <section>
+                    <h4>Subprotocols</h4>
+
+                    <p>
+                        The use of a subprotocol is expressed with the <code>subprotocol</code> field, as defined in
+                        [[!WOT-THING-DESCRIPTION]].
+                        It can be used in a form instance to indicate the use of one of these protocols, for example long polling with its
+                        special use of HTTP:
                     <pre class="example" title="Subprotocol usage for subscribing events">
-                        {
-                            "op": "subscribeevent",
-                            "href": "https://mylamp.example.com/overheating",
-                            "subprotocol": "longpoll"
-                        }
-                    </pre>
-                </p>
+                                            {
+                                                "op": "subscribeevent",
+                                                "href": "https://mylamp.example.com/overheating",
+                                                "subprotocol": "longpoll"
+                                            }
+                                        </pre>
+                    </p>
+                    
+                    <p>
+                        The values that the <code>subprotocol</code> term can take is not constrained by the [[!WOT-THING-DESCRIPTION]]
+                        since different protocols can have different Subprotocols.
+                        For WebSockets, the IANA-registered Websocket Subprotocols [[iana-web-socket-registry]] may be used.
+                        For CoAP, <code>"subprotocol":"cov:observe"</code> can be used to describe asynchronous observation
+                        operations as defined by [[RFC6741]].
+                        The subprotocols can be defined and explained as a part of a protocol or platform binding subspecification.
+                    </p>
+                </section>
 
-                <p>
-                    The values that the <code>subprotocol</code> term can take is not constrained by the [[!WOT-THING-DESCRIPTION]]
-                    since different protocols can have different Subprotocols.
-                    For WebSockets, the IANA-registered Websocket Subprotocols [[iana-web-socket-registry]] may be used.
-                    For CoAP, <code>"subprotocol":"cov:observe"</code> can be used to describe asynchronous observation
-                    operations as defined by [[RFC6741]].
-                    The subprotocols can be defined and explained as a part of a protocol or platform binding subspecification.
-                </p>
+            </section>
 
+            <section>
+                <h3>Terms Specified by Protocol Binding Templates</h3>
                 <p>
                     Overall, a protocol binding template specifies the values and structure of certain vocabulary terms in a TD.
-                    The table below lists the vocabulary term, the class it belongs to and whether the subspecification is required to
+                    The table below lists the vocabulary term, the class it belongs to and whether the subspecification is required
+                    to
                     specify the values the term can take.
                     In addition to these, additional terms for describing protocol options are typically added.
                 </p>
-
+            
                 <table class="def numbered" id="table-protocol-terms">
                     <caption>Terms specified by Protocol Binding Templates</caption>
                     <thead>
@@ -511,11 +522,11 @@
                             <td>Form</td>
                             <td>optional</td>
                         </tr>
-
+            
                     </tbody>
                 </table>
-                
             </section>
+
             <section id="protocol-bindings-table">
                 <h4>Existing Protocol Binding Templates</h4>
                 <p>
@@ -813,6 +824,9 @@
                         </tbody>
                     </table>
                 </section>
+            </section>
+            <section>
+                <h3>Terms Specified by Payload Binding Templates</h3>
                 <p>
                     Overall, a payload binding template specifies the values and structure of certain vocabulary terms in a TD.
                     The table below lists the vocabulary term, the class it belongs to and whether the subspecification is required to specify the values
@@ -854,6 +868,7 @@
                     </tbody>
                 </table>
             </section>
+
             <section id="payload-bindings-table">
                 <h4>Existing Payload Binding Templates</h4>
                 The table below summarizes the currently specified payload binding templates.


### PR DESCRIPTION
Some fixes towards #244 and #253

I think we need more concrete examples on where a protocol alone is not enough. E.g. putting no longpoll or sse for subscribeevent on HTTP and say that it is not possible to subscribe with no further information.

I have also changed the hierarchy a bit but it is only editorial


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/pull/283.html" title="Last updated on Apr 12, 2023, 1:20 PM UTC (97b6298)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/283/160d01d...97b6298.html" title="Last updated on Apr 12, 2023, 1:20 PM UTC (97b6298)">Diff</a>