### PR TITLE
Modbus: move required array to modbusForm

### DIFF
--- a/bindings/protocols/modbus/modbus.schema.json
+++ b/bindings/protocols/modbus/modbus.schema.json
@@ -50,9 +50,9 @@
                 "modbus:quantity" : { "type": "integer", "minimum": 1},
                 "modbus:zeroBasedAddressing" : { "type" : "boolean"},
                 "modbus:timeout" : { "type": "number", "minimum": 0},
-                "modbus:unitID": { "type": "integer", "minimum": 0},
-                "required": ["modbus:address", "modbus:unitID"]
-            }
+                "modbus:unitID": { "type": "integer", "minimum": 0}
+            },
+            "required": ["modbus:address", "modbus:unitID"]
         },
         "affordance": {
             "type": "object",


### PR DESCRIPTION
I updated the Modbus json schema and moved required array to modbusForm object. It was inside properties object but it should be inside modbusForm object.