### PR TITLE
Adding Jan Romann to CoAP codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 /bindings/payloads/xml/ @egekorkan @mjkoster
 /bindings/platforms/hue/ @egekorkan @mjkoster
 /bindings/protocols/bacnet/ @ektrah @mjkoster @fennibay 
-/bindings/protocols/coap/ @ektrah
+/bindings/protocols/coap/ @ektrah @JKRhb
 /bindings/protocols/http/ @egekorkan @mjkoster
 /bindings/protocols/modbus/ @relu91
 /bindings/protocols/mqtt/ @egekorkan @mjkoster @relu91


### PR DESCRIPTION
Since he is an editor of the document, he should be added to code owners file