### PR TITLE
chore: add BACnet protocol binding to the overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -577,6 +577,12 @@
                             <td><a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/index.html">Binding Template</a></td>
                             <td><a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/ontology.html">Ontology</a></td>
                         </tr>
+                        <tr>
+                            <td>BACnet</td>
+                            <td>BACnet</td>
+                            <td><a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/bacnet/index.html">Binding Template</a></td>
+                            <td><a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/bacnet/bacnet-model.ttl">Ontology</a></td>
+                        </tr>
                     </tbody>
                 </table>
             </section>


### PR DESCRIPTION
@egekorkan as discussed ~2 weeks ago, this adds BACnet to the bindings overview.

BACnet doesn't have its ontology rendered to HTML. I logged a separate issue for this: #333


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/pull/334.html" title="Last updated on Dec 5, 2023, 9:43 AM UTC (f757838)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/334/70554b1...f757838.html" title="Last updated on Dec 5, 2023, 9:43 AM UTC (f757838)">Diff</a>