### PR TITLE
Replace `cov:observe` subprotocol

### DIFF
--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -270,7 +270,7 @@
                 Consumers are generally expected to make use of both mechanisms to minimize the number of required CoAP transmissions.
             </p>
         </section>
-        <section>
+        <section id="polling-resources">
             <h3>Polling Resources</h3>
             <p>
                 A CoAP client may need a current representation of a resource over a period of time.
@@ -324,9 +324,6 @@
                 The server will then respond with the current representation of the resource, as well as send notifications to the client.
                 A server is not required to support the Observe option for all resources; in this case, a resource can still be observed by polling it at regular intervals.
             </p>
-            <p>
-                For the `observeproperty` and `subscribeevent` operation types, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
-            </p>
             <pre id="example-observing-resources" class="example" title="Observing Resources">
 {
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
@@ -346,7 +343,9 @@
 }
 </pre>
             <p>
-                A consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
+                For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
+                If the server's response does not contain an Observe option this indicates that the requested server does not support observe and that the consumer should fall back to polling instead (see section [[[#polling-resources]]]).
+                Consequently, a consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
                 possible.
                 In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
                 representation, setting the Observe option each time.

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -270,7 +270,7 @@
                 Consumers are generally expected to make use of both mechanisms to minimize the number of required CoAP transmissions.
             </p>
         </section>
-        <section>
+        <section id="polling-resources">
             <h3>Polling Resources</h3>
             <p>
                 A CoAP client may need a current representation of a resource over a period of time.

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -26,6 +26,31 @@
             edDraftURI: "https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/",
             shortName: "wot-coap-binding",
             github: "https://github.com/w3c/wot-binding-templates",
+            localBiblio: {
+                "I.D.-coap-pubsub": {
+                    href: "https://tools.ietf.org/html/draft-ietf-core-coap-pubsub-14",
+                    title: "A publish-subscribe architecture for the Constrained Application Protocol (CoAP)",
+                    status: "Internet-Draft",
+                    publisher: "IETF",
+                    date: "18 April 2024",
+                    authors: [
+                        "Jaime Jimenez",
+                        "Michael Koster",
+                        "Ari Keranen",
+                    ]
+                },
+                "I.D.-stp": {
+                    href: "https://datatracker.ietf.org/doc/html/draft-bormann-t2trg-stp-03",
+                    title: "The Series Transfer Pattern (STP)",
+                    status: "Internet-Draft",
+                    publisher: "IETF",
+                    date: "8 April 2020",
+                    authors: [
+                        "Carsten Bormann",
+                        "Klaus Hartke",
+                    ]
+                },
+            },
             otherLinks: [
               {
                 key: "Core Binding Templates Specification",
@@ -362,6 +387,10 @@
             <p>
                 The same considerations apply to the operations `observemultipleproperties`, `observeallproperties`, `subscribemultipleevents`, `subscribeallevents`, and their respective `unobserve-` and `unsubscribe-` counterparts.
                 Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or their surrounding environments to handle.
+            </p>
+            <p class="note" title="Advanced Event Mechanisms">
+                In the case of Event Affordances, CoAP Observe only supports a simply event notification mechanism that corresponds with the `data` field of the `EventAffordance` class within a Thing Description.
+                More complex event mechanisms may be supported via the procedures defined in specifications such as [[?I.D.-coap-pubsub]] or [[?I.D.-stp]] in the future.
             </p>
         </section>
         <section>

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -336,7 +336,7 @@
                 "cov:method": "GET",
                 "href": "coap://[2001:DB8::1]/status",
                 "contentType": "text/plain;charset=utf-8",
-                "op": ["observeproperty"]
+                "op": ["observeproperty", "unobserveproperty"]
             }]
         }
     }
@@ -351,6 +351,13 @@
                 representation, setting the Observe option each time.
                 As long as the client is receiving notifications, it doesn't need to poll; as soon as the notifications are missing,
                 the client polls again with the Observe option set.
+            </p>
+            <p>
+                The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe need to be performed as specified in section 3.6 of [[RFC7641]].
+                Note that this operation can be either performed actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
+                Therefore, for these operations to work, they MUST refer to the same resource as the matching `observeproperty` and `unsubscribeproperty` operations.
+                It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
+                If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is supposed to be used with the respective affordance.
             </p>
         </section>
         <section>

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -345,9 +345,9 @@
                 This is especially useful in the Web of Things where many Things are expected to have resources that change over time, such as sensor readings.
             </p>
             <p>
-                A resource can be observed by sending a GET or FETCH [[RFC8132]] request with the Observe option set.
-                The server will then respond with the current representation of the resource, as well as send notifications to the client.
-                A server is not required to support the Observe option for all resources; in this case, a resource can still be observed by polling it at regular intervals.
+                A resource can be observed by sending a `GET` or `FETCH` [[RFC8132]] request with the `Observe` option set.
+                The server will respond with the current representation of the resource, as well as sending future notifications to the client.
+                A server is not required to support the `Observe` option for all resources; a resource without `Observe` support can still be observed by polling it at regular intervals.
             </p>
             <pre id="example-observing-resources" class="example" title="Observing Resources">
 {
@@ -368,32 +368,32 @@
 }
 </pre>
             <p>
-                For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
-                Note, however, that using FETCH for the `observeproperty` operation is NOT RECOMMENDED as FETCH requests must contain a Content-Format option which can imply that the request payload must not be empty.
-                For the `subscribeevent` operation on the other hand, using FETCH is RECOMMENDED if the Event Affordance expects the consumer to provide data described by the `subscription` field.
+                For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an `Observe` option to `GET` or `FETCH` requests.
+                Note, however, that using `FETCH` for the `observeproperty` operation is NOT RECOMMENDED, as `FETCH` requests must contain a `Content-Format` option which can imply that the request payload must not be empty.
+                For the `subscribeevent` operation, on the other hand, using `FETCH` is RECOMMENDED if the Event Affordance expects the consumer to provide data described by the `subscription` field.
             </p>
             <p>
-                If the server's response does not contain an Observe option this indicates that the requested server does not support observe and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).
+                If the server's response does not contain an `Observe` option, this indicates that the requested server does not support observe, and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).
                 Consequently, a consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
                 possible.
                 In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
-                representation, setting the Observe option each time.
+                representation, setting the `Observe` option each time.
                 As long as the client is receiving notifications, it doesn't need to poll; as soon as the notifications are missing,
-                the client polls again with the Observe option set.
+                the client polls again with the `Observe` option set.
             </p>
             <p>
                 The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe MUST be performed as specified in section 3.6 of [[RFC7641]].
-                Note that this operation can be either performed actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
+                Note that this operation can be performed either actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
                 Therefore, for the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
                 It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
-                If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is supposed to be used with the respective affordance.
+                If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is meant to be used with the respective affordance.
             </p>
             <p>
                 The same considerations apply to the operations `observemultipleproperties`, `observeallproperties`, `subscribemultipleevents`, `subscribeallevents`, and their respective `unobserve-` and `unsubscribe-` counterparts.
                 Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or their surrounding environments to handle.
             </p>
             <p class="note" title="Advanced Event Mechanisms">
-                In the case of Event Affordances, CoAP Observe only supports a simple event notification mechanism that corresponds with the `data` field of the `EventAffordance` class within a Thing Description.
+                In the case of Event Affordances, CoAP Observe only supports a simply event notification mechanism that corresponds with the `data` field of the `EventAffordance` class within a Thing Description.
                 More complex event mechanisms may be supported via the procedures defined in specifications such as [[?I.D.-coap-pubsub]] or [[?I.D.-stp]] in the future.
             </p>
         </section>

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -346,9 +346,7 @@
             <p>
                 For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
                 If the server's response does not contain an Observe option this indicates that the requested server does not support observe and that the consumer should fall back to polling instead (see section [[[#polling-resources]]]).
-            </p>
-            <p>
-                A consumer can also always fall back to polling a resource if observing a resource is permanently or temporarily not
+                Consequently, a consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
                 possible.
                 In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
                 representation, setting the Observe option each time.

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -369,7 +369,11 @@
 </pre>
             <p>
                 For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
-                If the server's response does not contain an Observe option this indicates that the requested server does not support observe and that the consumer should fall back to polling instead (see section [[[#polling-resources]]]).
+                Note, however, that using FETCH for the `observeproperty` operation is NOT RECOMMENDED as FETCH requests must contain a Content-Format option which can imply that the request payload must not be empty.
+                For the `subscribeevent` operation on the other hand, using FETCH is RECOMMENDED if the Event Affordance expects the consumer to provide data described by the `subscription` field.
+            </p>
+            <p>
+                If the server's response does not contain an Observe option this indicates that the requested server does not support observe and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).
                 Consequently, a consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
                 possible.
                 In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
@@ -378,7 +382,7 @@
                 the client polls again with the Observe option set.
             </p>
             <p>
-                The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe need to be performed as specified in section 3.6 of [[RFC7641]].
+                The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe MUST be performed as specified in section 3.6 of [[RFC7641]].
                 Note that this operation can be either performed actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
                 Therefore, for the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
                 It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -359,6 +359,10 @@
                 It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
                 If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is supposed to be used with the respective affordance.
             </p>
+            <p>
+                The same considerations apply to the operations `observemultipleproperties`, `observeallproperties`, `subscribemultipleevents`, `subscribeallevents`, and their respective `unobserve-` and `unsubscribe-` counterparts.
+                Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or environments to handle.
+            </p>
         </section>
         <section>
             <h3>Block-wise Transfers</h3>

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -346,8 +346,8 @@
             </p>
             <p>
                 A resource can be observed by sending a `GET` or `FETCH` [[RFC8132]] request with the `Observe` option set.
-                The server will respond with the current representation of the resource, as well as sending future notifications to the client.
-                A server is not required to support the `Observe` option for all resources; a resource without `Observe` support can still be observed by polling it at regular intervals.
+                The server will respond with the current representation of the resource, and will send notifications of future changes to the client.
+                A server is not required to support the `Observe` option for all resources; a resource without `Observe` support can still be manually observed by polling it at regular intervals.
             </p>
             <pre id="example-observing-resources" class="example" title="Observing Resources">
 {
@@ -374,7 +374,7 @@
             </p>
             <p>
                 If the server's response does not contain an `Observe` option, this indicates that the requested server does not support observe, and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).
-                Consequently, a consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
+                Consequently, a consumer can always fall back to polling a resource if observing that resource is permanently or temporarily not
                 possible.
                 In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
                 representation, setting the `Observe` option each time.

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -320,7 +320,7 @@
                 This is especially useful in the Web of Things where many Things are expected to have resources that change over time, such as sensor readings.
             </p>
             <p>
-                A resource can be observed by sending a GET request with the Observe option set.
+                A resource can be observed by sending a GET or FETCH [[RFC8132]] request with the Observe option set.
                 The server will then respond with the current representation of the resource, as well as send notifications to the client.
                 A server is not required to support the Observe option for all resources; in this case, a resource can still be observed by polling it at regular intervals.
             </p>
@@ -339,7 +339,6 @@
                 "cov:method": "GET",
                 "href": "coap://[2001:DB8::1]/status",
                 "contentType": "text/plain;charset=utf-8",
-                "subprotocol": "cov:observe",
                 "op": ["observeproperty"]
             }]
         }
@@ -710,11 +709,11 @@
                     </tr>
                     <tr>
                         <td><code>observeproperty</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>unobserveproperty</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>readmultipleproperties</code></td>
@@ -734,11 +733,11 @@
                     </tr>
                     <tr>
                         <td><code>observeallproperties</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>unobserveallproperties</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>invokeaction</code></td>
@@ -758,19 +757,19 @@
                     </tr>
                     <tr>
                         <td><code>subscribeevent</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>unsubscribeevent</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>subscribeallevents</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>unsubscribeallevents</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                 </tbody>
             </table>

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -270,7 +270,7 @@
                 Consumers are generally expected to make use of both mechanisms to minimize the number of required CoAP transmissions.
             </p>
         </section>
-        <section id="polling-resources">
+        <section>
             <h3>Polling Resources</h3>
             <p>
                 A CoAP client may need a current representation of a resource over a period of time.

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -361,7 +361,7 @@
             </p>
             <p>
                 The same considerations apply to the operations `observemultipleproperties`, `observeallproperties`, `subscribemultipleevents`, `subscribeallevents`, and their respective `unobserve-` and `unsubscribe-` counterparts.
-                Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or environments to handle.
+                Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or their surrounding environments to handle.
             </p>
         </section>
         <section>

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -324,6 +324,9 @@
                 The server will then respond with the current representation of the resource, as well as send notifications to the client.
                 A server is not required to support the Observe option for all resources; in this case, a resource can still be observed by polling it at regular intervals.
             </p>
+            <p>
+                For the `observeproperty` and `subscribeevent` operation types, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
+            </p>
             <pre id="example-observing-resources" class="example" title="Observing Resources">
 {
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
@@ -344,9 +347,7 @@
 }
 </pre>
             <p>
-                For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
-                If the server's response does not contain an Observe option this indicates that the requested server does not support observe and that the consumer should fall back to polling instead (see section [[[#polling-resources]]]).
-                Consequently, a consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
+                A consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
                 possible.
                 In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
                 representation, setting the Observe option each time.

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -393,7 +393,7 @@
                 Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or their surrounding environments to handle.
             </p>
             <p class="note" title="Advanced Event Mechanisms">
-                In the case of Event Affordances, CoAP Observe only supports a simply event notification mechanism that corresponds with the `data` field of the `EventAffordance` class within a Thing Description.
+                In the case of Event Affordances, CoAP Observe only supports a simple event notification mechanism that corresponds with the `data` field of the `EventAffordance` class within a Thing Description.
                 More complex event mechanisms may be supported via the procedures defined in specifications such as [[?I.D.-coap-pubsub]] or [[?I.D.-stp]] in the future.
             </p>
         </section>

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -324,9 +324,6 @@
                 The server will then respond with the current representation of the resource, as well as send notifications to the client.
                 A server is not required to support the Observe option for all resources; in this case, a resource can still be observed by polling it at regular intervals.
             </p>
-            <p>
-                Support for observing resources can be indicating by including a <code>subprotocol</code> value of <code>cov:observe</code> in a form.
-            </p>
             <pre id="example-observing-resources" class="example" title="Observing Resources">
 {
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
@@ -347,7 +344,11 @@
 }
 </pre>
             <p>
-                A consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
+                For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
+                If the server's response does not contain an Observe option this indicates that the requested server does not support observe and that the consumer should fall back to polling instead (see section [[[#polling-resources]]]).
+            </p>
+            <p>
+                A consumer can also always fall back to polling a resource if observing a resource is permanently or temporarily not
                 possible.
                 In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
                 representation, setting the Observe option each time.

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -384,7 +384,7 @@
             <p>
                 The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe MUST be performed as specified in section 3.6 of [[RFC7641]].
                 Note that this operation can be performed either actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
-                Therefore, for the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
+                For the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
                 It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
                 If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is meant to be used with the respective affordance.
             </p>

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -380,7 +380,7 @@
             <p>
                 The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe need to be performed as specified in section 3.6 of [[RFC7641]].
                 Note that this operation can be either performed actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
-                Therefore, for these operations to work, they MUST refer to the same resource as the matching `observeproperty` and `unsubscribeproperty` operations.
+                Therefore, for the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
                 It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
                 If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is supposed to be used with the respective affordance.
             </p>

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -367,35 +367,6 @@
     }
 }
 </pre>
-            <p>
-                For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an `Observe` option to `GET` or `FETCH` requests.
-                Note, however, that using `FETCH` for the `observeproperty` operation is NOT RECOMMENDED, as `FETCH` requests must contain a `Content-Format` option which can imply that the request payload must not be empty.
-                For the `subscribeevent` operation, on the other hand, using `FETCH` is RECOMMENDED if the Event Affordance expects the consumer to provide data described by the `subscription` field.
-            </p>
-            <p>
-                If the server's response does not contain an `Observe` option, this indicates that the requested server does not support observe, and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).
-                Consequently, a consumer can always fall back to polling a resource if observing that resource is permanently or temporarily not
-                possible.
-                In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
-                representation, setting the `Observe` option each time.
-                As long as the client is receiving notifications, it doesn't need to poll; as soon as the notifications are missing,
-                the client polls again with the `Observe` option set.
-            </p>
-            <p>
-                The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe MUST be performed as specified in section 3.6 of [[RFC7641]].
-                Note that this operation can be performed either actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
-                For the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
-                It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
-                If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is meant to be used with the respective affordance.
-            </p>
-            <p>
-                The same considerations apply to the operations `observemultipleproperties`, `observeallproperties`, `subscribemultipleevents`, `subscribeallevents`, and their respective `unobserve-` and `unsubscribe-` counterparts.
-                Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or their surrounding environments to handle.
-            </p>
-            <p class="note" title="Advanced Event Mechanisms">
-                In the case of Event Affordances, CoAP Observe only supports a simply event notification mechanism that corresponds with the `data` field of the `EventAffordance` class within a Thing Description.
-                More complex event mechanisms may be supported via the procedures defined in specifications such as [[?I.D.-coap-pubsub]] or [[?I.D.-stp]] in the future.
-            </p>
         </section>
         <section>
             <h3>Block-wise Transfers</h3>
@@ -816,6 +787,35 @@
                     </tr>
                 </tbody>
             </table>
+            <p>
+                For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an `Observe` option to `GET` or `FETCH` requests.
+                Note, however, that using `FETCH` for the `observeproperty` operation is NOT RECOMMENDED, as `FETCH` requests must contain a `Content-Format` option which can imply that the request payload must not be empty.
+                For the `subscribeevent` operation, on the other hand, using `FETCH` is RECOMMENDED if the Event Affordance expects the consumer to provide data described by the `subscription` field.
+            </p>
+            <p>
+                If the server's response does not contain an `Observe` option, this indicates that the requested server does not support observe, and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).
+                Consequently, a consumer can always fall back to polling a resource if observing that resource is permanently or temporarily not
+                possible.
+                In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
+                representation, setting the `Observe` option each time.
+                As long as the client is receiving notifications, it doesn't need to poll; as soon as the notifications are missing,
+                the client polls again with the `Observe` option set.
+            </p>
+            <p>
+                The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe MUST be performed as specified in section 3.6 of [[RFC7641]].
+                Note that this operation can be performed either actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
+                For the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
+                It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
+                If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is meant to be used with the respective affordance.
+            </p>
+            <p>
+                The same considerations apply to the operations `observemultipleproperties`, `observeallproperties`, `subscribemultipleevents`, `subscribeallevents`, and their respective `unobserve-` and `unsubscribe-` counterparts.
+                Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or their surrounding environments to handle.
+            </p>
+            <p class="note" title="Advanced Event Mechanisms">
+                In the case of Event Affordances, CoAP Observe only supports a simply event notification mechanism that corresponds with the `data` field of the `EventAffordance` class within a Thing Description.
+                More complex event mechanisms may be supported via the procedures defined in specifications such as [[?I.D.-coap-pubsub]] or [[?I.D.-stp]] in the future.
+            </p>
         </section>
         <section id="possible-mappings">
             <h3>Possible mappings</h3>

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -270,7 +270,7 @@
                 Consumers are generally expected to make use of both mechanisms to minimize the number of required CoAP transmissions.
             </p>
         </section>
-        <section>
+        <section id="polling-resources">
             <h3>Polling Resources</h3>
             <p>
                 A CoAP client may need a current representation of a resource over a period of time.

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -26,6 +26,31 @@
             edDraftURI: "https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/",
             shortName: "wot-coap-binding",
             github: "https://github.com/w3c/wot-binding-templates",
+            localBiblio: {
+                "I.D.-coap-pubsub": {
+                    href: "https://tools.ietf.org/html/draft-ietf-core-coap-pubsub-14",
+                    title: "A publish-subscribe architecture for the Constrained Application Protocol (CoAP)",
+                    status: "Internet-Draft",
+                    publisher: "IETF",
+                    date: "18 April 2024",
+                    authors: [
+                        "Jaime Jimenez",
+                        "Michael Koster",
+                        "Ari Keranen",
+                    ]
+                },
+                "I.D.-stp": {
+                    href: "https://datatracker.ietf.org/doc/html/draft-bormann-t2trg-stp-03",
+                    title: "The Series Transfer Pattern (STP)",
+                    status: "Internet-Draft",
+                    publisher: "IETF",
+                    date: "8 April 2020",
+                    authors: [
+                        "Carsten Bormann",
+                        "Klaus Hartke",
+                    ]
+                },
+            },
             otherLinks: [
               {
                 key: "Core Binding Templates Specification",
@@ -362,6 +387,10 @@
             <p>
                 The same considerations apply to the operations `observemultipleproperties`, `observeallproperties`, `subscribemultipleevents`, `subscribeallevents`, and their respective `unobserve-` and `unsubscribe-` counterparts.
                 Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or their surrounding environments to handle.
+            </p>
+            <p class="note" title="Advanced Event Mechanisms">
+                In the case of Event Affordances, CoAP Observe only supports a simply event notification mechanism that corresponds with the `data` field of the `EventAffordance` class within a Thing Description.
+                More complex event mechanisms may be supported via the procedures defined in specifications such as [[?I.D.-coap-pubsub]] or [[?I.D.-stp]] in the future.
             </p>
         </section>
         <section>

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -382,7 +382,7 @@
                 the client polls again with the Observe option set.
             </p>
             <p>
-                The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe need to be performed as specified in section 3.6 of [[RFC7641]].
+                The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe MUST be performed as specified in section 3.6 of [[RFC7641]].
                 Note that this operation can be either performed actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
                 Therefore, for the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
                 It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -336,7 +336,7 @@
                 "cov:method": "GET",
                 "href": "coap://[2001:DB8::1]/status",
                 "contentType": "text/plain;charset=utf-8",
-                "op": ["observeproperty"]
+                "op": ["observeproperty", "unobserveproperty"]
             }]
         }
     }

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -359,6 +359,10 @@
                 It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
                 If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is supposed to be used with the respective affordance.
             </p>
+            <p>
+                The same considerations apply to the operations `observemultipleproperties`, `observeallproperties`, `subscribemultipleevents`, `subscribeallevents`, and their respective `unobserve-` and `unsubscribe-` counterparts.
+                Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or environments to handle.
+            </p>
         </section>
         <section>
             <h3>Block-wise Transfers</h3>

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -346,8 +346,8 @@
             </p>
             <p>
                 A resource can be observed by sending a `GET` or `FETCH` [[RFC8132]] request with the `Observe` option set.
-                The server will respond with the current representation of the resource, as well as sending future notifications to the client.
-                A server is not required to support the `Observe` option for all resources; a resource without `Observe` support can still be observed by polling it at regular intervals.
+                The server will respond with the current representation of the resource, and will send notifications of future changes to the client.
+                A server is not required to support the `Observe` option for all resources; a resource without `Observe` support can still be manually observed by polling it at regular intervals.
             </p>
             <pre id="example-observing-resources" class="example" title="Observing Resources">
 {
@@ -374,7 +374,7 @@
             </p>
             <p>
                 If the server's response does not contain an `Observe` option, this indicates that the requested server does not support observe, and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).
-                Consequently, a consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
+                Consequently, a consumer can always fall back to polling a resource if observing that resource is permanently or temporarily not
                 possible.
                 In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
                 representation, setting the `Observe` option each time.

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -352,6 +352,13 @@
                 As long as the client is receiving notifications, it doesn't need to poll; as soon as the notifications are missing,
                 the client polls again with the Observe option set.
             </p>
+            <p>
+                The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe need to be performed as specified in section 3.6 of [[RFC7641]].
+                Note that this operation can be either performed actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
+                Therefore, for these operations to work, they MUST refer to the same resource as the matching `observeproperty` and `unsubscribeproperty` operations.
+                It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
+                If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is supposed to be used with the respective affordance.
+            </p>
         </section>
         <section>
             <h3>Block-wise Transfers</h3>

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -373,7 +373,7 @@
                 For the `subscribeevent` operation on the other hand, using FETCH is RECOMMENDED if the Event Affordance expects the consumer to provide data described by the `subscription` field.
             </p>
             <p>
-                If the server's response does not contain an Observe option this indicates that the requested server does not support observe and that the consumer should fall back to polling instead (see section [[[#polling-resources]]]).
+                If the server's response does not contain an Observe option this indicates that the requested server does not support observe and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).
                 Consequently, a consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
                 possible.
                 In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -320,7 +320,7 @@
                 This is especially useful in the Web of Things where many Things are expected to have resources that change over time, such as sensor readings.
             </p>
             <p>
-                A resource can be observed by sending a GET request with the Observe option set.
+                A resource can be observed by sending a GET or FETCH [[RFC8132]] request with the Observe option set.
                 The server will then respond with the current representation of the resource, as well as send notifications to the client.
                 A server is not required to support the Observe option for all resources; in this case, a resource can still be observed by polling it at regular intervals.
             </p>

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -361,7 +361,7 @@
             </p>
             <p>
                 The same considerations apply to the operations `observemultipleproperties`, `observeallproperties`, `subscribemultipleevents`, `subscribeallevents`, and their respective `unobserve-` and `unsubscribe-` counterparts.
-                Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or environments to handle.
+                Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or their surrounding environments to handle.
             </p>
         </section>
         <section>

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -367,35 +367,6 @@
     }
 }
 </pre>
-            <p>
-                For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an `Observe` option to `GET` or `FETCH` requests.
-                Note, however, that using `FETCH` for the `observeproperty` operation is NOT RECOMMENDED, as `FETCH` requests must contain a `Content-Format` option which can imply that the request payload must not be empty.
-                For the `subscribeevent` operation, on the other hand, using `FETCH` is RECOMMENDED if the Event Affordance expects the consumer to provide data described by the `subscription` field.
-            </p>
-            <p>
-                If the server's response does not contain an `Observe` option, this indicates that the requested server does not support observe, and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).
-                Consequently, a consumer can always fall back to polling a resource if observing that resource is permanently or temporarily not
-                possible.
-                In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
-                representation, setting the `Observe` option each time.
-                As long as the client is receiving notifications, it doesn't need to poll; as soon as the notifications are missing,
-                the client polls again with the `Observe` option set.
-            </p>
-            <p>
-                The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe MUST be performed as specified in section 3.6 of [[RFC7641]].
-                Note that this operation can be performed either actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
-                For the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
-                It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
-                If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is meant to be used with the respective affordance.
-            </p>
-            <p>
-                The same considerations apply to the operations `observemultipleproperties`, `observeallproperties`, `subscribemultipleevents`, `subscribeallevents`, and their respective `unobserve-` and `unsubscribe-` counterparts.
-                Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or their surrounding environments to handle.
-            </p>
-            <p class="note" title="Advanced Event Mechanisms">
-                In the case of Event Affordances, CoAP Observe only supports a simply event notification mechanism that corresponds with the `data` field of the `EventAffordance` class within a Thing Description.
-                More complex event mechanisms may be supported via the procedures defined in specifications such as [[?I.D.-coap-pubsub]] or [[?I.D.-stp]] in the future.
-            </p>
         </section>
         <section>
             <h3>Block-wise Transfers</h3>
@@ -715,6 +686,35 @@
                     </tr>
                 </tbody>
             </table>
+            <p>
+                For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an `Observe` option to `GET` or `FETCH` requests.
+                Note, however, that using `FETCH` for the `observeproperty` operation is NOT RECOMMENDED, as `FETCH` requests must contain a `Content-Format` option which can imply that the request payload must not be empty.
+                For the `subscribeevent` operation, on the other hand, using `FETCH` is RECOMMENDED if the Event Affordance expects the consumer to provide data described by the `subscription` field.
+            </p>
+            <p>
+                If the server's response does not contain an `Observe` option, this indicates that the requested server does not support observe, and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).
+                Consequently, a consumer can always fall back to polling a resource if observing that resource is permanently or temporarily not
+                possible.
+                In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
+                representation, setting the `Observe` option each time.
+                As long as the client is receiving notifications, it doesn't need to poll; as soon as the notifications are missing,
+                the client polls again with the `Observe` option set.
+            </p>
+            <p>
+                The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe MUST be performed as specified in section 3.6 of [[RFC7641]].
+                Note that this operation can be performed either actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
+                For the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
+                It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
+                If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is meant to be used with the respective affordance.
+            </p>
+            <p>
+                The same considerations apply to the operations `observemultipleproperties`, `observeallproperties`, `subscribemultipleevents`, `subscribeallevents`, and their respective `unobserve-` and `unsubscribe-` counterparts.
+                Note, however, that it is NOT RECOMMENDED to use the `observeallproperties` and `subscribeallevents` operations with constrained devices that provide many properties and/or events, as the observe notifications may become too large for constrained devices or their surrounding environments to handle.
+            </p>
+            <p class="note" title="Advanced Event Mechanisms">
+                In the case of Event Affordances, CoAP Observe only supports a simply event notification mechanism that corresponds with the `data` field of the `EventAffordance` class within a Thing Description.
+                More complex event mechanisms may be supported via the procedures defined in specifications such as [[?I.D.-coap-pubsub]] or [[?I.D.-stp]] in the future.
+            </p>
         </section>
         <section id="possible-mappings">
             <h3>Possible mappings</h3>

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -383,10 +383,10 @@
             </p>
             <p>
                 The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe MUST be performed as specified in section 3.6 of [[RFC7641]].
-                Note that this operation can be either performed actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
+                Note that this operation can be performed either actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
                 Therefore, for the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
                 It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
-                If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is supposed to be used with the respective affordance.
+                If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is meant to be used with the respective affordance.
             </p>
             <p>
                 The same considerations apply to the operations `observemultipleproperties`, `observeallproperties`, `subscribemultipleevents`, `subscribeallevents`, and their respective `unobserve-` and `unsubscribe-` counterparts.

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -325,7 +325,7 @@
                 A server is not required to support the Observe option for all resources; in this case, a resource can still be observed by polling it at regular intervals.
             </p>
             <p>
-                Support for observing resources can be indicating by including a <code>subprotocol</code> value of <code>cov:observe</code> in a form.
+                For the `observeproperty` and `subscribeevent` operation types, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
             </p>
             <pre id="example-observing-resources" class="example" title="Observing Resources">
 {
@@ -339,7 +339,6 @@
                 "cov:method": "GET",
                 "href": "coap://[2001:DB8::1]/status",
                 "contentType": "text/plain;charset=utf-8",
-                "subprotocol": "cov:observe",
                 "op": ["observeproperty"]
             }]
         }
@@ -609,11 +608,11 @@
                     </tr>
                     <tr>
                         <td><code>observeproperty</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>unobserveproperty</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>readmultipleproperties</code></td>
@@ -633,11 +632,11 @@
                     </tr>
                     <tr>
                         <td><code>observeallproperties</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>unobserveallproperties</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>invokeaction</code></td>
@@ -657,19 +656,19 @@
                     </tr>
                     <tr>
                         <td><code>subscribeevent</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>unsubscribeevent</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>subscribeallevents</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                     <tr>
                         <td><code>unsubscribeallevents</code></td>
-                        <td><code>"cov:method": "GET"</code>, <code>"subprotocol": "cov:observe"</code></td>
+                        <td><code>"cov:method": "GET"</code></td>
                     </tr>
                 </tbody>
             </table>

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -369,8 +369,8 @@
 </pre>
             <p>
                 For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an `Observe` option to `GET` or `FETCH` requests.
-                Note, however, that using FETCH for the `observeproperty` operation is NOT RECOMMENDED as FETCH requests must contain a Content-Format option which can imply that the request payload must not be empty.
-                For the `subscribeevent` operation on the other hand, using FETCH is RECOMMENDED if the Event Affordance expects the consumer to provide data described by the `subscription` field.
+                Note, however, that using `FETCH` for the `observeproperty` operation is NOT RECOMMENDED, as `FETCH` requests must contain a `Content-Format` option which can imply that the request payload must not be empty.
+                For the `subscribeevent` operation, on the other hand, using `FETCH` is RECOMMENDED if the Event Affordance expects the consumer to provide data described by the `subscription` field.
             </p>
             <p>
                 If the server's response does not contain an `Observe` option, this indicates that the requested server does not support observe, and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -324,9 +324,6 @@
                 The server will then respond with the current representation of the resource, as well as send notifications to the client.
                 A server is not required to support the Observe option for all resources; in this case, a resource can still be observed by polling it at regular intervals.
             </p>
-            <p>
-                For the `observeproperty` and `subscribeevent` operation types, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
-            </p>
             <pre id="example-observing-resources" class="example" title="Observing Resources">
 {
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
@@ -346,7 +343,9 @@
 }
 </pre>
             <p>
-                A consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
+                For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
+                If the server's response does not contain an Observe option this indicates that the requested server does not support observe and that the consumer should fall back to polling instead (see section [[[#polling-resources]]]).
+                Consequently, a consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
                 possible.
                 In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
                 representation, setting the Observe option each time.

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -345,9 +345,9 @@
                 This is especially useful in the Web of Things where many Things are expected to have resources that change over time, such as sensor readings.
             </p>
             <p>
-                A resource can be observed by sending a GET or FETCH [[RFC8132]] request with the Observe option set.
-                The server will then respond with the current representation of the resource, as well as send notifications to the client.
-                A server is not required to support the Observe option for all resources; in this case, a resource can still be observed by polling it at regular intervals.
+                A resource can be observed by sending a `GET` or `FETCH` [[RFC8132]] request with the `Observe` option set.
+                The server will respond with the current representation of the resource, as well as sending future notifications to the client.
+                A server is not required to support the `Observe` option for all resources; a resource without `Observe` support can still be observed by polling it at regular intervals.
             </p>
             <pre id="example-observing-resources" class="example" title="Observing Resources">
 {
@@ -377,9 +377,9 @@
                 Consequently, a consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
                 possible.
                 In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current
-                representation, setting the Observe option each time.
+                representation, setting the `Observe` option each time.
                 As long as the client is receiving notifications, it doesn't need to poll; as soon as the notifications are missing,
-                the client polls again with the Observe option set.
+                the client polls again with the `Observe` option set.
             </p>
             <p>
                 The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe MUST be performed as specified in section 3.6 of [[RFC7641]].

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -384,7 +384,7 @@
             <p>
                 The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe MUST be performed as specified in section 3.6 of [[RFC7641]].
                 Note that this operation can be performed either actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
-                Therefore, for the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
+                For the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
                 It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
                 If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is meant to be used with the respective affordance.
             </p>

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -380,7 +380,7 @@
             <p>
                 The `unobserveproperty` and `unsubscribeevent` operations with CoAP observe need to be performed as specified in section 3.6 of [[RFC7641]].
                 Note that this operation can be either performed actively (i.e., by sending an explicit deregistration request) or passively (by "forgetting" the observe relation and sending a reset message after receiving the next notification response from the server).
-                Therefore, for these operations to work, they MUST refer to the same resource as the matching `observeproperty` and `unsubscribeproperty` operations.
+                Therefore, for the `unobserveproperty` and `unsubscribeevent` operations to work, they MUST refer to the same resource as the matching `observeproperty` and `subscribeevent` operations.
                 It is therefore RECOMMENDED to always include these operations in the same form as their counterparts when defining them for an affordance.
                 If no `unobserveproperty` or `unsubscribeevent` operation is defined for an observable property or an event, it SHOULD be assumed that the "passive" deregistration variant is supposed to be used with the respective affordance.
             </p>

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -368,12 +368,12 @@
 }
 </pre>
             <p>
-                For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
+                For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an `Observe` option to `GET` or `FETCH` requests.
                 Note, however, that using FETCH for the `observeproperty` operation is NOT RECOMMENDED as FETCH requests must contain a Content-Format option which can imply that the request payload must not be empty.
                 For the `subscribeevent` operation on the other hand, using FETCH is RECOMMENDED if the Event Affordance expects the consumer to provide data described by the `subscription` field.
             </p>
             <p>
-                If the server's response does not contain an Observe option this indicates that the requested server does not support observe and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).
+                If the server's response does not contain an `Observe` option, this indicates that the requested server does not support observe, and that the consumer SHOULD fall back to polling instead (see section [[[#polling-resources]]]).
                 Consequently, a consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
                 possible.
                 In fact, a typical CoAP client implementation is to poll for as long as the client is interested in having a current

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -369,6 +369,10 @@
 </pre>
             <p>
                 For the `observeproperty` and `subscribeevent` operations, a consumer SHOULD add an Observe option to GET or FETCH requests by default.
+                Note, however, that using FETCH for the `observeproperty` operation is NOT RECOMMENDED as FETCH requests must contain a Content-Format option which can imply that the request payload must not be empty.
+                For the `subscribeevent` operation on the other hand, using FETCH is RECOMMENDED if the Event Affordance expects the consumer to provide data described by the `subscription` field.
+            </p>
+            <p>
                 If the server's response does not contain an Observe option this indicates that the requested server does not support observe and that the consumer should fall back to polling instead (see section [[[#polling-resources]]]).
                 Consequently, a consumer can always fall back to polling a resource if observing a resource is permanently or temporarily not
                 possible.

--- a/index.html
+++ b/index.html
@@ -460,10 +460,8 @@
                     since different protocols can have different subprotocols.
                     Correspondingly, subprotocols are linked to the protocol they are extending and should be understood together with 
                     the protocol indicated in <code>href</code> of the forms (or the <code>base</code>).
-                    For WebSockets, the IANA-registered Websocket Subprotocols [[iana-web-socket-registry]] may be used.
-                    For CoAP, <code>"subprotocol":"cov:observe"</code> can be used to describe asynchronous observation
-                    operations as defined by [[RFC6741]].
-                    The subprotocols can be defined and explained as a part of a protocol or platform binding subspecification.
+                    For WebSockets, the IANA-registered Websocket Subprotocols [[iana-web-socket-registry]] may be used, for example.
+                    Subprotocols can be defined and explained as a part of a protocol or platform binding subspecification.
                 </p>
             </section>
 
@@ -1285,8 +1283,7 @@
                             "cov:method": "GET",
                             "href": "coap://example.com/sensor/gasconcentration",
                             "contentType": "application/json",
-                            "op": "subscribeevent",
-                            "subprotocol": "cov:observe"
+                            "op": ["subscribeevent", "ubsubscribeevent"],
                         }
                     ]
                 }

--- a/index.html
+++ b/index.html
@@ -1283,7 +1283,7 @@
                             "cov:method": "GET",
                             "href": "coap://example.com/sensor/gasconcentration",
                             "contentType": "application/json",
-                            "op": ["subscribeevent", "ubsubscribeevent"],
+                            "op": ["subscribeevent", "unsubscribeevent"],
                         }
                     ]
                 }


### PR DESCRIPTION
Based on the discussion in #348, this PR applies some initial changes to the CoAP Binding Template document concerning removing the `cov:subprotocol` which has been identified as not actually necessary. It also makes a minor addition by mentioning that Observe can also be used with the FETCH method.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-binding-templates/pull/353.html" title="Last updated on Aug 8, 2024, 1:14 PM UTC (bf7da92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/353/3ce9e2b...JKRhb:bf7da92.html" title="Last updated on Aug 8, 2024, 1:14 PM UTC (bf7da92)">Diff</a>