### PR TITLE
Small Modbus fixes

### DIFF
--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -122,13 +122,13 @@
         moment.
         The following shows the typical structure of an URL of the Modbus TCP protocol:
         <pre>
-            modbus+tcp://{address}:{port}/{unitID}/{address}?quantity={?quantity}
+            modbus+tcp://{deviceAddress}:{port}/{unitID}/{address}?quantity={?quantity}
         </pre>
 
         <p>
             Where:
             <ul>
-                <li><code>{address}</code> is the IP address of the Modbus device</li>
+                <li><code>{deviceAddress}</code> is the IP address of the Modbus device</li>
                 <li><code>{port}</code> is the port of the Modbus device</li>
                 <li><code>{unitID}</code> is the unit ID of the Modbus device. See <a href="#vocabulary">vocabulary</a></li>
                 <li><code>{address}</code> is the address of the register/coil referenced in this URL. See <a href="#vocabulary">vocabulary</a></li>
@@ -652,8 +652,7 @@
                 "op": [
                     "readproperty"
                 ],
-                "modv:function": "readCoil",
-                "modv:address": 1
+                "modv:function": "readCoil"
             }
         </pre>
         To describe forms with multiple operations types, the [[[#entity]]] keyword can be used to create 
@@ -665,7 +664,7 @@
                             "readproperty",
                             "writeproperty"
                         ],
-                        "modv:entity": "Coil",
+                        "modv:entity": "Coil"
                     }
         </pre>
         A TD processor will intepred [[[#example-read-coil-entity]]] configuration as the following:
@@ -675,14 +674,14 @@
                                 "op": [
                                     "readproperty",
                                 ],
-                                "modv:function": "readCoil",
+                                "modv:function": "readCoil"
                             },
                             {
                                 "href": "modbus+tcp://127.0.0.1:60000/1/1",
                                 "op": [
                                     "writeproperty",
                                 ],
-                                "modv:function": "writeCoil",
+                                "modv:function": "writeCoil"
                             }]
         </pre>
         Reducing effectively the verbosity of a TD. 
@@ -743,7 +742,7 @@
                     "observeproperty"
                 ],
                 "modv:entity": "Coil",
-                "modv:pollingTime": 1000,
+                "modv:pollingTime": 1000
             }
         </pre>
         Finally, [[[#full-td]]] shows a complete device described using Modbus ontology.

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -122,13 +122,13 @@
         moment.
         The following shows the typical structure of an URL of the Modbus TCP protocol:
         <pre>
-            modbus+tcp://{address}:{port}/{unitID}/{address}?quantity={?quantity}
+            modbus+tcp://{deviceAddress}:{port}/{unitID}/{address}?quantity={?quantity}
         </pre>
 
         <p>
             Where:
             <ul>
-                <li><code>{address}</code> is the IP address of the Modbus device</li>
+                <li><code>{deviceAddress}</code> is the IP address of the Modbus device</li>
                 <li><code>{port}</code> is the port of the Modbus device</li>
                 <li><code>{unitID}</code> is the unit ID of the Modbus device. See <a href="#vocabulary">vocabulary</a></li>
                 <li><code>{address}</code> is the address of the register/coil referenced in this URL. See <a href="#vocabulary">vocabulary</a></li>
@@ -379,8 +379,7 @@
                 "op": [
                     "readproperty"
                 ],
-                "modv:function": "readCoil",
-                "modv:address": 1
+                "modv:function": "readCoil"
             }
         </pre>
         To describe forms with multiple operations types, the [[[#entity]]] keyword can be used to create 
@@ -392,7 +391,7 @@
                             "readproperty",
                             "writeproperty"
                         ],
-                        "modv:entity": "Coil",
+                        "modv:entity": "Coil"
                     }
         </pre>
         A TD processor will intepred [[[#example-read-coil-entity]]] configuration as the following:
@@ -402,14 +401,14 @@
                                 "op": [
                                     "readproperty",
                                 ],
-                                "modv:function": "readCoil",
+                                "modv:function": "readCoil"
                             },
                             {
                                 "href": "modbus+tcp://127.0.0.1:60000/1/1",
                                 "op": [
                                     "writeproperty",
                                 ],
-                                "modv:function": "writeCoil",
+                                "modv:function": "writeCoil"
                             }]
         </pre>
         Reducing effectively the verbosity of a TD. 
@@ -470,7 +469,7 @@
                     "observeproperty"
                 ],
                 "modv:entity": "Coil",
-                "modv:pollingTime": 1000,
+                "modv:pollingTime": 1000
             }
         </pre>
         Finally, [[[#full-td]]] shows a complete device described using Modbus ontology.


### PR DESCRIPTION
There were some leftover commas at the end of forms and one form had leftover modv:address even though it is now in the URI