### PR TITLE
Header Alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1007,7 +1007,7 @@
             </section>
             
             <section>
-                <h5>Creating a new Platform Binding Template Subspecification</h5>
+                <h4>Creating a new Platform Binding Template Subspecification</h4>
 
                 <p>
                     Depending on the platform and the variety of devices it proposes, each platform binding template

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
     </section>
 
     <section id="introduction">
-        <h1>Introduction</h1>
+        <h2>Introduction</h2>
         <p>
             IoT addresses multiple use cases from different application domains, while requiring different deployment patterns for devices.
             This results in different protocols and media types, creating the central challenge for the Web of Things: 
@@ -263,7 +263,7 @@
     </section>
 
     <section id="binding-overview">
-        <h1>Binding Template Mechanisms</h1>
+        <h2>Binding Template Mechanisms</h2>
 
         <p>
             TDs can be bound to specific protocols, payload formats and platforms.
@@ -288,8 +288,8 @@
             publication date.
             This document, called the <a>Binding Template Core Specification</a>, explains the binding mechanism by
             giving requirements per respective binding category and links to the respective subspecification.
-            These can be found in sections [[[#protocol-bindings]]], [[[#payload-bindings-intro]]] and
-            [[[#platform-bindings-intro]]].
+            These can be found in sections [[[#protocol-bindings]]], [[[#payload-bindings]]] and
+            [[[#platform-bindings]]].
         </p>
     
         <figure id="fig-overview">
@@ -307,178 +307,173 @@
         </p>
 
         <section id="protocol-bindings">
-            <h3>Protocol Binding Templates</h3>
-            <section id="protocol-bindings-intro">
-                <h3>Introduction to Protocol Binding Templates</h3>
-                <p>
-                    [[WOT-THING-DESCRIPTION]] defines abstract operations such as <code>readproperty</code>, <code>invokeaction</code> and
-                    <code>subscribeevent</code> that describe the intended semantics of performing the operation described
-                    by the form in a <a>Thing Description</a>.
-                    In order for the operations to be performed on the affordance, a binding of the operation to the
-                    protocol needs to happen.
-                    In other words, the form needs to contain all the information for a Consumer to, for example read a property,
-                    with the protocol in the form.
-                </p>
-                <p>
-                    Most protocols have a relatively small set of methods that define the message type, the semantic
-                    intention of the message.
-                    REST and PubSub architecture patterns result in different protocols with different methods.
-                    Each target protocol may specify different method names for similar operations, and there may be
-                    semantic differences between similar method names of different protocols.
-                    Additionally, <a>Things</a> may use different methods for performing a particular WoT operation.
-                    For example, an HTTP POST request may be used for a <code>writeproperty</code> operation in one Thing,
-                    while HTTP PUT may be used in another.
-                    For these reasons, Thing Descriptions require the ability to specify which method to use per operation.
-                </p>
-                <p>
-                    Common methods found in REST and PubSub protocols are GET, PUT, POST, DELETE, PUBLISH, and SUBSCRIBE.
-                    Binding Templates describe how these existing methods and associated vocabularies can be used in
-                    a <a>Thing Description</a> to bind to the WoT operations.
-                    This is done by defining the URI scheme of the protocol and mapping the protocol
-                    methods to the abstract WoT operations such as <code>readproperty</code>, <code>invokeaction</code> and
-                    <code>subscribeevent</code>.
-                    In some cases, additional instructions are provided to explain how the vocabulary terms should be used
-                    in different cases of protocol usage.
-                </p>
-                <p>
-                    The examples below show the binding of the <code>readproperty</code> operation for the HTTP and Modbus protocols.
-                    Please note that these are examples and please always refer to the corresponding binding to learn about the
-                    relevant vocabulary terms and their values.
-                </p>
-                <table>
-                    <tbody>
-                        <tr>
-                            <td style="vertical-align: top; width: 50%">
-                                <pre class="example" title="Binding example of a readproperty operation to HTTP">
-                                    {
-                                        "href": "http://example.com/props/temperature",
-                                        "op": "readproperty",
-                                        "htv:methodName": "GET"
-                                    }
-                                </pre>
-                            </td>
-                            <td style="vertical-align: top; width: 50%">
-                                <pre class="example" title="Binding example of a readproperty operation to Modbus">
-                                    {
-                                        "href": "modbus+tcp://127.0.0.1:60000/1",
-                                        "op": "readproperty",
-                                        "modv:function": "readCoil",
-                                        "modv:address": 1
-                                    }
-                                </pre>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+        <h3>Protocol Binding Templates</h3>
+            <p>
+                [[WOT-THING-DESCRIPTION]] defines abstract operations such as <code>readproperty</code>, <code>invokeaction</code> and
+                <code>subscribeevent</code> that describe the intended semantics of performing the operation described
+                by the form in a <a>Thing Description</a>.
+                In order for the operations to be performed on the affordance, a binding of the operation to the
+                protocol needs to happen.
+                In other words, the form needs to contain all the information for a Consumer to, for example read a property,
+                with the protocol in the form.
+            </p>
+            <p>
+                Most protocols have a relatively small set of methods that define the message type, the semantic
+                intention of the message.
+                REST and PubSub architecture patterns result in different protocols with different methods.
+                Each target protocol may specify different method names for similar operations, and there may be
+                semantic differences between similar method names of different protocols.
+                Additionally, <a>Things</a> may use different methods for performing a particular WoT operation.
+                For example, an HTTP POST request may be used for a <code>writeproperty</code> operation in one Thing,
+                while HTTP PUT may be used in another.
+                For these reasons, Thing Descriptions require the ability to specify which method to use per operation.
+            </p>
+            <p>
+                Common methods found in REST and PubSub protocols are GET, PUT, POST, DELETE, PUBLISH, and SUBSCRIBE.
+                Binding Templates describe how these existing methods and associated vocabularies can be used in
+                a <a>Thing Description</a> to bind to the WoT operations.
+                This is done by defining the URI scheme of the protocol and mapping the protocol
+                methods to the abstract WoT operations such as <code>readproperty</code>, <code>invokeaction</code> and
+                <code>subscribeevent</code>.
+                In some cases, additional instructions are provided to explain how the vocabulary terms should be used
+                in different cases of protocol usage.
+            </p>
+            <p>
+                The examples below show the binding of the <code>readproperty</code> operation for the HTTP and Modbus protocols.
+                Please note that these are examples and please always refer to the corresponding binding to learn about the
+                relevant vocabulary terms and their values.
+            </p>
+            <table>
+                <tbody>
+                    <tr>
+                        <td style="vertical-align: top; width: 50%">
+                            <pre class="example" title="Binding example of a readproperty operation to HTTP">
+                                {
+                                    "href": "http://example.com/props/temperature",
+                                    "op": "readproperty",
+                                    "htv:methodName": "GET"
+                                }
+                            </pre>
+                        </td>
+                        <td style="vertical-align: top; width: 50%">
+                            <pre class="example" title="Binding example of a readproperty operation to Modbus">
+                                {
+                                    "href": "modbus+tcp://127.0.0.1:60000/1",
+                                    "op": "readproperty",
+                                    "modv:function": "readCoil",
+                                    "modv:address": 1
+                                }
+                            </pre>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <p>
+                The form elements in the examples above convey the following statements:
+            </p>
+            <ul>
+                <li>
+                    Left Example: To do a <code>readproperty</code> of the subject Property Affordance by
+                    performing an HTTP GET request on the resource <code>props/temperature</code> to the host
+                    at <code>example.com</code> on port <code>80</code> (Port 80 is assumed as per [[RFC2616]]).
+                </li>
+                <li>
+                    Right Example: To do a <code>readproperty</code> of the subject Property Affordance using the
+                    <code>readCoil</code> function of Modbus at coil <code>1</code> of the device
+                    with the <code>127.0.0.1</code> address at its port <code>60000</code>
+                </li>
+            </ul>
+            <p>
+                These bindings and their statements are possible for other operations and protocols as well.
+                Below are examples for <code>invokeaction</code> and <code>subscribeevent</code>:
+            </p>
+
+            <table>
+                <tbody>
+                    <tr>
+                        <td style="vertical-align: top; width: 50%">
+                            <pre class="example" title="Binding example of an invokeaction operation to HTTP">
+                                {
+                                    "op": "invokeaction",
+                                    "href": "http://192.168.1.32:8081/example/levelaction",
+                                    "htv:methodName": "POST"
+                                }
+                            </pre>
+                        </td>
+                        <td style="vertical-align: top; width: 50%">
+                            <pre class="example" title="Binding example of a subscribeevent operation to MQTT">
+                                {
+                                    "op": "subscribeevent",
+                                    "href": "mqtt://iot.platform.com:8088",
+                                    "mqv:filter": "thing1/events/overheating",
+                                    "mqv:controlPacket": "subscribe"
+                                }
+                            </pre>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <p>
+                The form elements in the examples above convey the following statements:
+            </p>
+            <ul>
+                <li>
+                    Left Example: To do an <code>invokeaction</code> of the subject Action Affordance by
+                    performing an HTTP POST request on the resource <code>example/levelaction</code> to the host
+                    at <code>192.168.1.32</code> on port <code>8081</code>.
+                </li>
+                <li>
+                    Right Example: To do a <code>subscribeevent</code> of the subject Event Affordance by connecting
+                    to the MQTT broker at <code>iot.platform.com</code> and port <code>8088</code>, then subscribing
+                    to the topic <code>thing1/events/overheating</code>.
+                </li>
+            </ul>
+        
+            <p>
+                In some cases, header options or other parameters of the protocols need to be included.
+                Given that these are highly protocol dependent, please refer to the bindings listed in [[[#protocol-bindings-table]]].
+                Additionally, protocols may have defined Subprotocols that can be used for some interaction types.
+                For example, to receive asynchronous notifications using HTTP, some servers may support long polling
+                    (<code>longpoll</code>), WebSub [[WebSub]] (<code>websub</code>) and Server-Sent Events [[eventsource]] (<code>sse</code>).
+            </p>
+
+            <section>
+                <h4>Subprotocols</h4>
 
                 <p>
-                    The form elements in the examples above convey the following statements:
-                </p>
-                <ul>
-                    <li>
-                        Left Example: To do a <code>readproperty</code> of the subject Property Affordance by
-                        performing an HTTP GET request on the resource <code>props/temperature</code> to the host
-                        at <code>example.com</code> on port <code>80</code> (Port 80 is assumed as per [[RFC2616]]).
-                    </li>
-                    <li>
-                        Right Example: To do a <code>readproperty</code> of the subject Property Affordance using the
-                        <code>readCoil</code> function of Modbus at coil <code>1</code> of the device
-                        with the <code>127.0.0.1</code> address at its port <code>60000</code>
-                    </li>
-                </ul>
-                <p>
-                    These bindings and their statements are possible for other operations and protocols as well.
-                    Below are examples for <code>invokeaction</code> and <code>subscribeevent</code>:
+                    As defined in  [[WOT-ARCHITECTURE]], a subprotocol is an extension mechanism to a protocol.
+                    A subprotocol can require a sequence of protocol messages or a specific structure of message payloads,
+                    which can have its own semantics within that subprotocol.
+                    The use of a subprotocol is expressed with the <code>subprotocol</code> field, as defined in
+                    [[!WOT-THING-DESCRIPTION]].
+                    It can be used in a form instance to indicate the use of one of these protocols, for example long polling with its
+                    special use of HTTP:
                 </p>
 
-                <table>
-                    <tbody>
-                        <tr>
-                            <td style="vertical-align: top; width: 50%">
-                                <pre class="example" title="Binding example of an invokeaction operation to HTTP">
-                                    {
-                                        "op": "invokeaction",
-                                        "href": "http://192.168.1.32:8081/example/levelaction",
-                                        "htv:methodName": "POST"
-                                    }
-                                </pre>
-                            </td>
-                            <td style="vertical-align: top; width: 50%">
-                                <pre class="example" title="Binding example of a subscribeevent operation to MQTT">
-                                    {
-                                        "op": "subscribeevent",
-                                        "href": "mqtt://iot.platform.com:8088",
-                                        "mqv:filter": "thing1/events/overheating",
-                                        "mqv:controlPacket": "subscribe"
-                                    }
-                                </pre>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-
-                <p>
-                    The form elements in the examples above convey the following statements:
-                </p>
-                <ul>
-                    <li>
-                        Left Example: To do an <code>invokeaction</code> of the subject Action Affordance by
-                        performing an HTTP POST request on the resource <code>example/levelaction</code> to the host
-                        at <code>192.168.1.32</code> on port <code>8081</code>.
-                    </li>
-                    <li>
-                        Right Example: To do a <code>subscribeevent</code> of the subject Event Affordance by connecting
-                        to the MQTT broker at <code>iot.platform.com</code> and port <code>8088</code>, then subscribing
-                        to the topic <code>thing1/events/overheating</code>.
-                    </li>
-                </ul>
+                <pre class="example" title="Subprotocol usage for subscribing events">
+                    {
+                        "op": "subscribeevent",
+                        "href": "https://mylamp.example.com/overheating",
+                        "subprotocol": "longpoll"
+                    }
+                </pre>
                 
-
                 <p>
-                    In some cases, header options or other parameters of the protocols need to be included.
-                    Given that these are highly protocol dependent, please refer to the bindings listed in [[[#protocol-bindings-table]]].
-                    Additionally, protocols may have defined Subprotocols that can be used for some interaction types.
-                    For example, to receive asynchronous notifications using HTTP, some servers may support long polling
-                     (<code>longpoll</code>), WebSub [[WebSub]] (<code>websub</code>) and Server-Sent Events [[eventsource]] (<code>sse</code>).
+                    The values that the <code>subprotocol</code> term can take is not constrained by the [[!WOT-THING-DESCRIPTION]]
+                    since different protocols can have different subprotocols.
+                    Correspondingly, subprotocols are linked to the protocol they are extending and should be understood together with 
+                    the protocol indicated in <code>href</code> of the forms (or the <code>base</code>).
+                    For WebSockets, the IANA-registered Websocket Subprotocols [[iana-web-socket-registry]] may be used.
+                    For CoAP, <code>"subprotocol":"cov:observe"</code> can be used to describe asynchronous observation
+                    operations as defined by [[RFC6741]].
+                    The subprotocols can be defined and explained as a part of a protocol or platform binding subspecification.
                 </p>
-
-                <section>
-                    <h4>Subprotocols</h4>
-
-                    <p>
-                        As defined in  [[WOT-ARCHITECTURE]], a subprotocol is an extension mechanism to a protocol.
-                        A subprotocol can require a sequence of protocol messages or a specific structure of message payloads,
-                        which can have its own semantics within that subprotocol.
-                        The use of a subprotocol is expressed with the <code>subprotocol</code> field, as defined in
-                        [[!WOT-THING-DESCRIPTION]].
-                        It can be used in a form instance to indicate the use of one of these protocols, for example long polling with its
-                        special use of HTTP:
-                    </p>
-
-                    <pre class="example" title="Subprotocol usage for subscribing events">
-                        {
-                            "op": "subscribeevent",
-                            "href": "https://mylamp.example.com/overheating",
-                            "subprotocol": "longpoll"
-                        }
-                    </pre>
-                   
-                    <p>
-                        The values that the <code>subprotocol</code> term can take is not constrained by the [[!WOT-THING-DESCRIPTION]]
-                        since different protocols can have different subprotocols.
-                        Correspondingly, subprotocols are linked to the protocol they are extending and should be understood together with 
-                        the protocol indicated in <code>href</code> of the forms (or the <code>base</code>).
-                        For WebSockets, the IANA-registered Websocket Subprotocols [[iana-web-socket-registry]] may be used.
-                        For CoAP, <code>"subprotocol":"cov:observe"</code> can be used to describe asynchronous observation
-                        operations as defined by [[RFC6741]].
-                        The subprotocols can be defined and explained as a part of a protocol or platform binding subspecification.
-                    </p>
-                </section>
-
             </section>
 
             <section>
-                <h3>Terms Specified by Protocol Binding Templates</h3>
+                <h4>Terms Specified by Protocol Binding Templates</h4>
                 <p>
                     Overall, a protocol binding template specifies the values and structure of certain vocabulary terms in a TD.
                     The table below lists the vocabulary term, the class it belongs to and whether the subspecification is required
@@ -586,6 +581,7 @@
                     </tbody>
                 </table>
             </section>
+
             <section>
                 <h4>Using a Thing Description with a Protocol Binding Template Subspecification</h4>
 
@@ -615,6 +611,7 @@
                 </ol>
                 
             </section>
+
             <section>
                 <h4>Creating a new Protocol Binding Template Subspecification</h4>
 
@@ -680,175 +677,172 @@
         </section>
 
         <section id="payload-bindings">
-            <h3>Payload Binding Templates</h3>
-            <section id="payload-bindings-intro">
-                <h4>Introduction to Payload Binding Templates</h4>
+            <h3>Payload Binding Templates</h3>               
+            <p>
+                [[WOT-THING-DESCRIPTION]] defines two mechanisms to describe how a payload of a message over any protocol
+                can look like.
+                Firstly, media types [[IANA-MEDIA-TYPES]] describe the serialization used for sending and receiving the data with a protocol.
+                They are represented within the <code>contentType</code> in the Forms of a TD, which is mandatory for
+                each Interaction Affordance.
+                Secondly, it defines the Data Schema concept to describe the structure of the messages, which are used
+                together with media types.
+                The combination of the two allows any message to be described in a TD, allowing correct serialization and
+                deserialization of the messages by the Thing and Consumers.
+            </p>
+
+            <p>
+                In the rest of this section at [[[#payload-bindings-contentType]]] and [[[#payload-bindings-dataschema]]],
+                you can find examples of how payload bindings can look like.
+                At [[[#payload-bindings-table]]] you can find the current payload binding templates and [[[#payload-bindings-creating]]]
+                explains how new payload binding templates can be created.
+            </p>
+            <section id="payload-bindings-contentType">
+                <h4>Content Types</h4>
+
                 <p>
-                    [[WOT-THING-DESCRIPTION]] defines two mechanisms to describe how a payload of a message over any protocol
-                    can look like.
-                    Firstly, media types [[IANA-MEDIA-TYPES]] describe the serialization used for sending and receiving the data with a protocol.
-                    They are represented within the <code>contentType</code> in the Forms of a TD, which is mandatory for
-                    each Interaction Affordance.
-                    Secondly, it defines the Data Schema concept to describe the structure of the messages, which are used
-                    together with media types.
-                    The combination of the two allows any message to be described in a TD, allowing correct serialization and
-                    deserialization of the messages by the Thing and Consumers.
+                    Content type includes the media type and potential parameters for the media type and it enables
+                        proper processing of the serialized documents.
+                    This way, the messages can be exchanged in any format and allow the upper layers of an application
+                    to adapt to different formats.
+                    In some cases such as images, videos or any unstructured data, content type is enough to describe the
+                    payload but in cases like JSON ([[RFC8259]]) a Data Schema is usually provided, like explained in [[[#payload-bindings-dataschema]]].
+                </p>
+                <p>
+                    For example, a number payload can be serialized as JSON or XML and be indicated in the <code>contentType</code>
+                    of the forms with <code>application/json</code> or <code>application/xml</code>, respectively.
+                    Further parametrization is possible via the plus (<code>+</code>) or the semicolon (<code>;</code>)
+                    notations.
                 </p>
 
                 <p>
-                    In the rest of this section at [[[#payload-bindings-contentType]]] and [[[#payload-bindings-dataschema]]],
-                    you can find examples of how payload bindings can look like.
-                    At [[[#payload-bindings-table]]] you can find the current payload binding templates and [[[#payload-bindings-creating]]]
-                    explains how new payload binding templates can be created.
+                    In the example below, you can find the form elements with content types for JSON and plain text
+                        with additional parameters.
+                    In this specific case, the forms describe that reading this property with <code>http</code> or
+                    <code>coap</code> result in different content types.
+                    For structured media types, a Data Schema is generally provided in the affordance level as
+                    explained in [[[#payload-bindings-dataschema]]] and <a data-cite="WOT-THING-DESCRIPTION#sec-data-schema-vocabulary-definition">
+                    in the Data Schema section of the TD specification</a>.
+                    However, for unstructured data such as images and videos, a Data Schema is typically not available.
                 </p>
-                <section id="payload-bindings-contentType">
-                    <h5>Content Types</h5>
 
-                    <p>
-                        Content type includes the media type and potential parameters for the media type and it enables
-                         proper processing of the serialized documents.
-                        This way, the messages can be exchanged in any format and allow the upper layers of an application
-                        to adapt to different formats.
-                        In some cases such as images, videos or any unstructured data, content type is enough to describe the
-                        payload but in cases like JSON ([[RFC8259]]) a Data Schema is usually provided, like explained in [[[#payload-bindings-dataschema]]].
-                    </p>
-                    <p>
-                        For example, a number payload can be serialized as JSON or XML and be indicated in the <code>contentType</code>
-                        of the forms with <code>application/json</code> or <code>application/xml</code>, respectively.
-                        Further parametrization is possible via the plus (<code>+</code>) or the semicolon (<code>;</code>)
-                        notations.
-                    </p>
-
-                    <p>
-                        In the example below, you can find the form elements with content types for JSON and plain text
-                         with additional parameters.
-                        In this specific case, the forms describe that reading this property with <code>http</code> or
-                        <code>coap</code> result in different content types.
-                        For structured media types, a Data Schema is generally provided in the affordance level as
-                        explained in [[[#payload-bindings-dataschema]]] and <a data-cite="WOT-THING-DESCRIPTION#sec-data-schema-vocabulary-definition">
-                        in the Data Schema section of the TD specification</a>.
-                        However, for unstructured data such as images and videos, a Data Schema is typically not available.
-                    </p>
-
-                    <pre class="example" title="JSON and CBOR media types in forms" id="example-payload-binding">
+                <pre class="example" title="JSON and CBOR media types in forms" id="example-payload-binding">
+                    {
+                        "forms":[
                         {
-                            "forms":[
-                            {
-                                "href": "http://example.com/properties/temperature",
-                                "op": "readproperty",
-                                "contentType": "application/json"
-                            },
-                            {
-                                "href": "coap://example.com/properties/temperature",
-                                "op": "readproperty",
-                                "contentType": "text/plain;charset=utf-8"
-                            }]
-                        }
-                    </pre>
+                            "href": "http://example.com/properties/temperature",
+                            "op": "readproperty",
+                            "contentType": "application/json"
+                        },
+                        {
+                            "href": "coap://example.com/properties/temperature",
+                            "op": "readproperty",
+                            "contentType": "text/plain;charset=utf-8"
+                        }]
+                    }
+                </pre>
 
-                    <p>
-                        Other content types can be also expressed in TDs.
-                        In the list below, examples of different content type variations can be found.
-                        These content types can replace the ones in [[[#example-payload-binding]]].
-                    </p>
+                <p>
+                    Other content types can be also expressed in TDs.
+                    In the list below, examples of different content type variations can be found.
+                    These content types can replace the ones in [[[#example-payload-binding]]].
+                </p>
 
-                    <ul>
-                        <li>Structured Content Types without Parametrization
-                            <ul>
-                                <li><code>application/json</code>: JSON [[RFC8259]]</li>
-                                <li><code>application/xml</code>: XML [[RFC5364]]</li>
-                                <li><code>application/cbor</code>: CBOR [[RFC8949]]</li>
-                                <li><code>text/csv</code>: CSV [[RFC4180]]</li>
-                            </ul>
-                        </li>
-                        <li>Structured Content Types with Parametrization
-                            <ul>
-                                <li><code>application/senml+json</code>: SenML Data serialized in JSON [[RFC8259]]</li>
-                                <li><code>application/senml+xml</code>: SenML Data serialized as XML</li>
-                                <li><code>application/ocf+cbor</code>: OCF payload serialized in CBOR</li>
-                                <li><code>text/csv;charset=utf-8</code>: CSV encoded in UTF-8 [[RFC4180]]</li>
-                            </ul>
-                        </li>
-                        <li>Unstructured Content Types
-                            <ul>
-                                <li><code>image/jpeg</code>: JPEG image</li>
-                                <li><code>video/mp4</code>: MP4 Video</li>
-                                <li><code>application/octet-stream</code>: Generic binary stream</li>
-                            </ul>
-                        </li>
-                    </ul>
-                </section>
-                <section id="payload-bindings-dataschema">
-                    <h5>Data Schemas</h5>
+                <ul>
+                    <li>Structured Content Types without Parametrization
+                        <ul>
+                            <li><code>application/json</code>: JSON [[RFC8259]]</li>
+                            <li><code>application/xml</code>: XML [[RFC5364]]</li>
+                            <li><code>application/cbor</code>: CBOR [[RFC8949]]</li>
+                            <li><code>text/csv</code>: CSV [[RFC4180]]</li>
+                        </ul>
+                    </li>
+                    <li>Structured Content Types with Parametrization
+                        <ul>
+                            <li><code>application/senml+json</code>: SenML Data serialized in JSON [[RFC8259]]</li>
+                            <li><code>application/senml+xml</code>: SenML Data serialized as XML</li>
+                            <li><code>application/ocf+cbor</code>: OCF payload serialized in CBOR</li>
+                            <li><code>text/csv;charset=utf-8</code>: CSV encoded in UTF-8 [[RFC4180]]</li>
+                        </ul>
+                    </li>
+                    <li>Unstructured Content Types
+                        <ul>
+                            <li><code>image/jpeg</code>: JPEG image</li>
+                            <li><code>video/mp4</code>: MP4 Video</li>
+                            <li><code>application/octet-stream</code>: Generic binary stream</li>
+                        </ul>
+                    </li>
+                </ul>
+            </section>
+            <section id="payload-bindings-dataschema">
+                <h4>Data Schemas</h4>
 
-                    <p>
-                        Data Schema, as explained in [[WOT-THING-DESCRIPTION]], describes the structure of the messages, which are used together with media types.
-                        Even though it is largely inspired by JSON Schema [[json-schema]], it can be used for describing
-                        other payload types such as [[XML]], string-encoded images, bit representations of integers, etc.
-                        Data Schema SHOULD be used in addition to the media types.
-                    </p>
-                    <p>
-                        Depending on the case, the structure of the messages can be anything from a simple number to
-                        arrays or objects with multiple levels of nesting.
-                        Existing IoT Platforms and Standards have certain payload formats with variations on how the data is structured.
-                        As explained in [[WOT-THING-DESCRIPTION]], Data Schema can be used in a TD in one of the following places:
-                    </p>
-                    <ul>
-                        <li><b>Property Affordances:</b> Each property affordance can contain terms for Data Schema
-                        and describe the property values when read, observed or written to.</li>
-                        <li><b>Action Affordances:</b> <code>input</code> and <code>output</code> vocabulary terms are used 
-                            to provide two different schemas when data is exchanged in both directions, such as in 
-                            the case of invoking an Action Affordance with input parameters and receiving status information.</li>
-                        <li><b>Event Affordances:</b> <code>data</code>, <code>dataResponse</code>, <code>subscription</code>
-                            and <code>cancellation</code> are used to describe the payload when the event data
-                            is delivered by the Exposed Thing, the payload to reply with for event deliveries,
-                                the payload needed to subscribe to the event and the payload needed to cancel receiving event
-                            data from the Exposed Thing, respectively.</li>
-                        <li><b>URI Variables:</b> In the Thing or Affordance level, <code>uriVariables</code> can
-                        describe the data that needs to be supplied inside the request URI as a string.</li>
-                    </ul>
-                    
-                    <p>
-                        Below is an example of a simple JSON object payload with the corresponding Data Schema.
-                        Examples from various IoT Platforms and Standards can be found in [[[#sec-payload-examples]]].
-                    </p>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td style="vertical-align: top; width: 50%">
-                                    <pre class="example" title="Simple JSON Object Payload">
-                                        {
-                                            "level": 50,
-                                            "time": 10
-                                        }
-                                    </pre>
-                                </td>
-                                <td style="vertical-align: top; width: 50%">
-                                    <pre class="example" title="DataSchema for Simple JSON Object Payload">
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "level": {
-                                                    "type": "integer",
-                                                    "minimum": 0,
-                                                    "maximum": 255
-                                                },
-                                                "time": {
-                                                    "type": "integer",
-                                                    "minimum": 0,
-                                                    "maximum": 65535
-                                                }
+                <p>
+                    Data Schema, as explained in [[WOT-THING-DESCRIPTION]], describes the structure of the messages, which are used together with media types.
+                    Even though it is largely inspired by JSON Schema [[json-schema]], it can be used for describing
+                    other payload types such as [[XML]], string-encoded images, bit representations of integers, etc.
+                    Data Schema SHOULD be used in addition to the media types.
+                </p>
+                <p>
+                    Depending on the case, the structure of the messages can be anything from a simple number to
+                    arrays or objects with multiple levels of nesting.
+                    Existing IoT Platforms and Standards have certain payload formats with variations on how the data is structured.
+                    As explained in [[WOT-THING-DESCRIPTION]], Data Schema can be used in a TD in one of the following places:
+                </p>
+                <ul>
+                    <li><b>Property Affordances:</b> Each property affordance can contain terms for Data Schema
+                    and describe the property values when read, observed or written to.</li>
+                    <li><b>Action Affordances:</b> <code>input</code> and <code>output</code> vocabulary terms are used 
+                        to provide two different schemas when data is exchanged in both directions, such as in 
+                        the case of invoking an Action Affordance with input parameters and receiving status information.</li>
+                    <li><b>Event Affordances:</b> <code>data</code>, <code>dataResponse</code>, <code>subscription</code>
+                        and <code>cancellation</code> are used to describe the payload when the event data
+                        is delivered by the Exposed Thing, the payload to reply with for event deliveries,
+                            the payload needed to subscribe to the event and the payload needed to cancel receiving event
+                        data from the Exposed Thing, respectively.</li>
+                    <li><b>URI Variables:</b> In the Thing or Affordance level, <code>uriVariables</code> can
+                    describe the data that needs to be supplied inside the request URI as a string.</li>
+                </ul>
+                
+                <p>
+                    Below is an example of a simple JSON object payload with the corresponding Data Schema.
+                    Examples from various IoT Platforms and Standards can be found in [[[#sec-payload-examples]]].
+                </p>
+                <table>
+                    <tbody>
+                        <tr>
+                            <td style="vertical-align: top; width: 50%">
+                                <pre class="example" title="Simple JSON Object Payload">
+                                    {
+                                        "level": 50,
+                                        "time": 10
+                                    }
+                                </pre>
+                            </td>
+                            <td style="vertical-align: top; width: 50%">
+                                <pre class="example" title="DataSchema for Simple JSON Object Payload">
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "level": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "maximum": 255
+                                            },
+                                            "time": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "maximum": 65535
                                             }
                                         }
-                                    </pre>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </section>
+                                    }
+                                </pre>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
             </section>
             <section>
-                <h3>Terms Specified by Payload Binding Templates</h3>
+                <h4>Terms Specified by Payload Binding Templates</h4>
                 <p>
                     Overall, a payload binding template specifies the values and structure of certain vocabulary terms in a TD.
                     The table below lists the vocabulary term, the class it belongs to and whether the subspecification is required to specify the values
@@ -959,33 +953,31 @@
                 
             </section>
         </section>
+        
         <section id="platform-bindings">
             <h3>Platform Binding Templates</h3>
-            <section id="platform-bindings-intro">
-            <h3>Introduction to Platform Binding Templates</h3>
-                <p>
-                    There are already various IoT platforms on the market that allows exposing physical and virtual Things to the Internet.
-                    These platforms generally require a certain use of a protocol and payload.
-                    Thus, they can be seen as a combination of the <a href="#protocol-bindings"></a> and <a href="#payload-bindings"></a>.
-                    In these cases, the use of protocol and payload bindings needs to be supported with how they are related to each other in the specific platform.
-                </p>
-                
-                <p>
-                    For example, Things of a certain platform can require the usage of HTTP and Websockets together with certain JSON payload structures.
-                    Thus, Platform Binding <a>subspecification</a>s provide Thing Models and examples of TDs that allow to semantically group multiple binding templates.
-                    This allows creation of TDs for these platforms in a consistent manner and makes it easier to develop <a>Consumer</a>s for them.
-                </p>
+            <p>
+                There are already various IoT platforms on the market that allows exposing physical and virtual Things to the Internet.
+                These platforms generally require a certain use of a protocol and payload.
+                Thus, they can be seen as a combination of the <a href="#protocol-bindings"></a> and <a href="#payload-bindings"></a>.
+                In these cases, the use of protocol and payload bindings needs to be supported with how they are related to each other in the specific platform.
+            </p>
+            
+            <p>
+                For example, Things of a certain platform can require the usage of HTTP and Websockets together with certain JSON payload structures.
+                Thus, Platform Binding <a>subspecification</a>s provide Thing Models and examples of TDs that allow to semantically group multiple binding templates.
+                This allows creation of TDs for these platforms in a consistent manner and makes it easier to develop <a>Consumer</a>s for them.
+            </p>
 
-                <p>
-                    Since Platform Binding Templates combine the usage of protocol and payload binding templates, the vocabulary terms and values they can specify
-                    are the combination of vocabulary terms in [[[#table-protocol-terms]]] and [[[#table-payload-terms]]].
-                    Similarly, a Platform Binding subspecification SHOULD NOT introduce new protocol binding templates or media types inside its own document.
-                    If a Platform Binding subspecification requires the usage of protocol or media type, corresponding protocol or payload binding templates MUST be created first.
-                </p>
-            </section>
+            <p>
+                Since Platform Binding Templates combine the usage of protocol and payload binding templates, the vocabulary terms and values they can specify
+                are the combination of vocabulary terms in [[[#table-protocol-terms]]] and [[[#table-payload-terms]]].
+                Similarly, a Platform Binding subspecification SHOULD NOT introduce new protocol binding templates or media types inside its own document.
+                If a Platform Binding subspecification requires the usage of protocol or media type, corresponding protocol or payload binding templates MUST be created first.
+            </p>
 
             <section id="platform-bindings-table">
-                <h3>Existing Platform Binding Templates</h3>
+                <h4>Existing Platform Binding Templates</h4>
                 <p>
                     The table below summarizes the currently specified platform binding template <a>subspecification</a>s.
                 </p>
@@ -1015,7 +1007,7 @@
             </section>
             
             <section>
-                <h4>Creating a new Platform Binding Template Subspecification</h4>
+                <h5>Creating a new Platform Binding Template Subspecification</h5>
 
                 <p>
                     Depending on the platform and the variety of devices it proposes, each platform binding template
@@ -1047,7 +1039,7 @@
     </section>
 
     <section id="binding-examples" class="informative">
-        <h1>Examples of Thing Descriptions with Protocol Binding Templates</h1>
+        <h2>Examples of Thing Descriptions with Protocol Binding Templates</h2>
 
         <p>
             The following TD examples uses HTTP, CoAP and MQTT Protocol Binding Templates.
@@ -1309,7 +1301,7 @@
     </section>
 
     <section id="sec-security-considerations">
-        <h1>Security and Privacy Considerations</h1>
+        <h2>Security and Privacy Considerations</h2>
 
         <p class="ednote">
             Security and privacy considerations are still under discussion and development; the content below should be


### PR DESCRIPTION
I have noticed that many headers were h1 (shouldn't be multiple and h1 is not allowed anyways) and we had too many levels due to usage of "introduction" section.

This content is being moved to TD but this will be a small alignment before the move. A PR is being created in the TD repo


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/pull/360.html" title="Last updated on Apr 18, 2024, 6:28 AM UTC (02895f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/360/b0600ce...02895f9.html" title="Last updated on Apr 18, 2024, 6:28 AM UTC (02895f9)">Diff</a>