### PR TITLE
Add dark mode support

### DIFF
--- a/bindings/index.template.html
+++ b/bindings/index.template.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
         var respecConfig = {

--- a/bindings/payloads/xml/index.html
+++ b/bindings/payloads/xml/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
         var respecConfig = {

--- a/bindings/platforms/hue/index.html
+++ b/bindings/platforms/hue/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
         var respecConfig = {

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
         var respecConfig = {

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
         var respecConfig = {

--- a/bindings/protocols/coap/ontology.html
+++ b/bindings/protocols/coap/ontology.html
@@ -3,6 +3,7 @@
 <html>
     <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove' defer></script>
     <script class='remove'>
         var respecConfig = {

--- a/bindings/protocols/http/index.html
+++ b/bindings/protocols/http/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
         var respecConfig = {

--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
         var respecConfig = {

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
         var respecConfig = {

--- a/bindings/protocols/modbus/ontology.html
+++ b/bindings/protocols/modbus/ontology.html
@@ -1,12 +1,14 @@
+
 <!DOCTYPE html>
 <html>
     <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove' defer></script>
     <script class='remove'>
         var respecConfig = {
             specStatus: "ED",
-            editors: [],
+            editors: [{name:"Cristiano Aguzzi",company:"Invited Expert",companyURL:"https://github.com/relu91"}],
             group: "wg/wot",
             edDraftURI: "https://www.w3.org/2019/wot/modbus",
             shortName: "wot-binding-templates"

--- a/bindings/protocols/mqtt/index.html
+++ b/bindings/protocols/mqtt/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
         var respecConfig = {

--- a/bindings/protocols/mqtt/index.template.html
+++ b/bindings/protocols/mqtt/index.template.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
         var respecConfig = {

--- a/bindings/protocols/mqtt/ontology.html
+++ b/bindings/protocols/mqtt/ontology.html
@@ -3,6 +3,7 @@
 <html>
     <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove' defer></script>
     <script class='remove'>
         var respecConfig = {

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
     <title>Web of Things (WoT) Binding Templates</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <script class="remove">

--- a/ontology/templates.rq
+++ b/ontology/templates.rq
@@ -15,6 +15,7 @@ template :main(?ns) {
 <html>
     <head>
     <meta charset='utf-8'>
+    <meta name='color-scheme' content='light dark'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove' defer></script>
     <script class='remove'>
         var respecConfig = {


### PR DESCRIPTION
As also discussed over at https://github.com/w3c/wot-thing-description/pull/2029, this simple PR enables dark mode support for all the documents (or rather: their current draft versions) in this repository.

Note that there are some unrelated changes occurring with the Modbus ontology – maybe that one should be regenerated on the `main` branch?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-binding-templates/pull/375.html" title="Last updated on Jul 10, 2024, 10:07 AM UTC (182868a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-templates/375/18051f3...JKRhb:182868a.html" title="Last updated on Jul 10, 2024, 10:07 AM UTC (182868a)">Diff</a>