### PR TITLE
BACnet protocol binding improvements

### DIFF
--- a/bindings/protocols/bacnet/bacnet-model.ttl
+++ b/bindings/protocols/bacnet/bacnet-model.ttl
@@ -27,7 +27,7 @@
                                 # dcterms:rights "TODO" ;
                                 dcterms:title "BACnet Model" ;
                                 dcterms:source "http://www.w3.org/2022/bacnet" ;
-                                vann:preferredNamespacePrefix "bacnet" ;
+                                vann:preferredNamespacePrefix "bacv" ;
                                 vann:preferredNamespaceUri bacv: ;
                                 vaem:hasOwner "Dogan Fennibay" ;
                                 owl:versionInfo "0.1.1" ;

--- a/bindings/protocols/bacnet/bacnet-model.ttl
+++ b/bindings/protocols/bacnet/bacnet-model.ttl
@@ -10,7 +10,7 @@
 @prefix vaem: <http://www.linkedmodel.org/schema/vaem#> .
 @prefix td: <https://www.w3.org/2019/wot/td#> .
 @prefix jsonschema: <https://www.w3.org/2019/wot/json-schema#> .
-@prefix bacnet: <http://www.w3.org/2022/bacnet#> .
+@prefix bacv: <http://www.w3.org/2022/bacnet#> .
 
 @base <http://www.w3.org/2022/bacnet> .
 
@@ -28,7 +28,7 @@
                                 dcterms:title "BACnet Model" ;
                                 dcterms:source "http://www.w3.org/2022/bacnet" ;
                                 vann:preferredNamespacePrefix "bacnet" ;
-                                vann:preferredNamespaceUri bacnet: ;
+                                vann:preferredNamespaceUri bacv: ;
                                 vaem:hasOwner "Dogan Fennibay" ;
                                 owl:versionInfo "0.1.1" ;
                                 rdfs:comment """
@@ -51,7 +51,7 @@ Additional parameters can be specified via URI variable syntax, e.g. ?commandPri
 #    Communication properties
 #################################################################
 
-bacnet:usesService rdf:type owl:DatatypeProperty ;
+bacv:usesService rdf:type owl:DatatypeProperty ;
                    rdfs:domain hctl:Form ;
                    rdfs:range [owl:oneOf ("ReadProperty"^^xsd:string "WriteProperty"^^xsd:string "SubscribeCOV"^^xsd:string)] ;
                    rdfs:comment """
@@ -71,7 +71,7 @@ Not mapped yet:
 - td:subscribeAllEvents, td:unsubscribeAllEvents
 """@en .
 
-bacnet:CovIncrement rdf:type owl:Class ;
+bacv:CovIncrement rdf:type owl:Class ;
                     rdfs:subClassOf jsonschema:NumberSchema ;
                     rdfs:subClassOf [
                         a owl:Restriction ;
@@ -81,7 +81,7 @@ bacnet:CovIncrement rdf:type owl:Class ;
                     rdfs:comment "Specifies the minimum change for numeric values in that will cause a COV notification to be issued to subscribers. Only applies when SubscribeCOVProperty is used. If missing for the present-value, the default value on the object will be used instead."@en ;
                     rdfs:seeAlso "ASHRAE 135-2020 BACnet 13.1 Change of Value Reporting" .
 
-bacnet:CommandPriority rdf:type owl:Class ;
+bacv:CommandPriority rdf:type owl:Class ;
                        rdfs:subClassOf jsonschema:IntegerSchema ;
                        rdfs:subClassOf [
                            a owl:Restriction ;
@@ -105,95 +105,95 @@ bacnet:CommandPriority rdf:type owl:Class ;
 # the type information has to be amended in the protocol binding.
 #################################################################
 
-bacnet:hasDataType rdf:type owl:ObjectProperty ;
-                   rdfs:domain [ owl:unionOf (hctl:Form bacnet:NamedMember) ] ;
-                   rdfs:range bacnet:DataType .
+bacv:hasDataType rdf:type owl:ObjectProperty ;
+                   rdfs:domain [ owl:unionOf (hctl:Form bacv:NamedMember) ] ;
+                   rdfs:range bacv:DataType .
 
-bacnet:DataType rdf:type owl:Class ;
+bacv:DataType rdf:type owl:Class ;
                 rdfs:comment "Base for all BACnet data types" .
 
-bacnet:SequenceOf rdfs:subClassOf bacnet:DataType .
+bacv:SequenceOf rdfs:subClassOf bacv:DataType .
 
-bacnet:Sequence rdfs:subClassOf bacnet:DataType .
+bacv:Sequence rdfs:subClassOf bacv:DataType .
 
-bacnet:List rdfs:subClassOf bacnet:DataType .
+bacv:List rdfs:subClassOf bacv:DataType .
 
-bacnet:Choice rdfs:subClassOf bacnet:DataType .
+bacv:Choice rdfs:subClassOf bacv:DataType .
 
-bacnet:Date rdfs:subClassOf bacnet:DataType .
+bacv:Date rdfs:subClassOf bacv:DataType .
 
-bacnet:Time rdfs:subClassOf bacnet:DataType .
+bacv:Time rdfs:subClassOf bacv:DataType .
 
-bacnet:WeekNDay rdfs:subClassOf bacnet:DataType .
+bacv:WeekNDay rdfs:subClassOf bacv:DataType .
 
-bacnet:Unsigned rdfs:subClassOf bacnet:DataType .
+bacv:Unsigned rdfs:subClassOf bacv:DataType .
 
-bacnet:Signed rdfs:subClassOf bacnet:DataType .
+bacv:Signed rdfs:subClassOf bacv:DataType .
 
-bacnet:Real rdfs:subClassOf bacnet:DataType .
+bacv:Real rdfs:subClassOf bacv:DataType .
 
-bacnet:Double rdfs:subClassOf bacnet:DataType .
+bacv:Double rdfs:subClassOf bacv:DataType .
 
-bacnet:Boolean rdfs:subClassOf bacnet:DataType .
+bacv:Boolean rdfs:subClassOf bacv:DataType .
 
-bacnet:Enumerated rdfs:subClassOf bacnet:DataType .
+bacv:Enumerated rdfs:subClassOf bacv:DataType .
 
-bacnet:String rdfs:subClassOf bacnet:DataType .
+bacv:String rdfs:subClassOf bacv:DataType .
 
-bacnet:OctetString rdfs:subClassOf bacnet:DataType .
+bacv:OctetString rdfs:subClassOf bacv:DataType .
 
-bacnet:BitString rdfs:subClassOf bacnet:DataType .
+bacv:BitString rdfs:subClassOf bacv:DataType .
 
-bacnet:Any rdfs:subClassOf bacnet:DataType .
+bacv:Any rdfs:subClassOf bacv:DataType .
 
-bacnet:Null rdfs:subClassOf bacnet:DataType .
+bacv:Null rdfs:subClassOf bacv:DataType .
 
-bacnet:ObjectIdentifier rdfs:subClassOf bacnet:DataType .
+bacv:ObjectIdentifier rdfs:subClassOf bacv:DataType .
 
-bacnet:isIso8601 rdf:type owl:DatatypeProperty ;
-                 rdfs:domain bacnet:Sequence ;
+bacv:isIso8601 rdf:type owl:DatatypeProperty ;
+                 rdfs:domain bacv:Sequence ;
                  rdfs:range xsd:boolean ;
                  rdfs:comment "This field indicates that the Sequence has a date and a time field, and should be collectively represented in the ISO 8601 (aka. RFC 3339, section 5.6) format"@en .
 
-bacnet:hasBinaryRepresentation rdf:type owl:DatatypeProperty ;
-                               rdfs:domain bacnet:OctetString ;
+bacv:hasBinaryRepresentation rdf:type owl:DatatypeProperty ;
+                               rdfs:domain bacv:OctetString ;
                                rdfs:range [owl:oneOf ("hex"^^xsd:string "dotted-decimal"^^xsd:string "base64"^^xsd:string)] .
 
-bacnet:hasMember rdf:type owl:ObjectProperty ;
-                 rdfs:domain [owl:unionOf (bacnet:SequenceOf bacnet:List ) ];
-                 rdfs:range bacnet:DataType .
+bacv:hasMember rdf:type owl:ObjectProperty ;
+                 rdfs:domain [owl:unionOf (bacv:SequenceOf bacv:List ) ];
+                 rdfs:range bacv:DataType .
 
-bacnet:hasNamedMember rdf:type owl:ObjectProperty ;
-                 rdfs:domain [owl:unionOf (bacnet:Sequence bacnet:Choice ) ];
-                 rdfs:range bacnet:NamedMember .
+bacv:hasNamedMember rdf:type owl:ObjectProperty ;
+                 rdfs:domain [owl:unionOf (bacv:Sequence bacv:Choice ) ];
+                 rdfs:range bacv:NamedMember .
 
-bacnet:NamedMember rdf:type owl:Class .
+bacv:NamedMember rdf:type owl:Class .
 
-bacnet:hasFieldName rdf:type owl:DatatypeProperty ;
-                    rdfs:domain bacnet:NamedMember ;
+bacv:hasFieldName rdf:type owl:DatatypeProperty ;
+                    rdfs:domain bacv:NamedMember ;
                     rdfs:range xsd:string .
 
-bacnet:hasContextTag rdf:type owl:DatatypeProperty ;
-                     rdfs:domain bacnet:NamedMember ;
+bacv:hasContextTag rdf:type owl:DatatypeProperty ;
+                     rdfs:domain bacv:NamedMember ;
                      rdfs:range xsd:integer .
 
-bacnet:ValueMap rdf:type owl:Class .
+bacv:ValueMap rdf:type owl:Class .
 
-bacnet:ValueMapEntry rdf:type owl:Class .
+bacv:ValueMapEntry rdf:type owl:Class .
 
-bacnet:hasMapEntry rdf:type owl:ObjectProperty ;
-                   rdfs:domain bacnet:ValueMap ;
-                   rdfs:range bacnet:ValueMapEntry .
+bacv:hasMapEntry rdf:type owl:ObjectProperty ;
+                   rdfs:domain bacv:ValueMap ;
+                   rdfs:range bacv:ValueMapEntry .
 
-bacnet:hasLogicalVal rdf:type owl:DatatypeProperty ;
-                     rdfs:domain bacnet:ValueMapEntry ;
+bacv:hasLogicalVal rdf:type owl:DatatypeProperty ;
+                     rdfs:domain bacv:ValueMapEntry ;
                      rdfs:range [owl:unionOf (xsd:integer xsd:string xsd:boolean)] .
 
-bacnet:hasProtocolVal rdf:type rdf:type owl:DatatypeProperty ;
-                      rdfs:domain bacnet:ValueMapEntry ;
+bacv:hasProtocolVal rdf:type rdf:type owl:DatatypeProperty ;
+                      rdfs:domain bacv:ValueMapEntry ;
                       rdfs:range xsd:integer .
 
 
-bacnet:hasValueMap rdf:type owl:ObjectProperty ;
-                   rdfs:domain [owl:unionOf (bacnet:Boolean bacnet:Enumerated bacnet:Unsigned bacnet:BitString)] ;
-                   rdfs:range bacnet:ValueMap .
+bacv:hasValueMap rdf:type owl:ObjectProperty ;
+                   rdfs:domain [owl:unionOf (bacv:Boolean bacv:Enumerated bacv:Unsigned bacv:BitString)] ;
+                   rdfs:range bacv:ValueMap .

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -76,13 +76,17 @@
         <p>
             In the context of the Web of Things (WoT), a Binding Template is a blueprint that gives guidance on how to
             implement a specific IoT protocol, data format, or IoT platform.
-            The Core Binding Templates specification explains the overall mechanism and requirements for any binding to follow.
-            This document gives implementation guidelines regarding BACnet [[BACnet]], a building automation and control networking protocol.
+            The Core Binding Templates specification explains the overall mechanism and requirements for any binding to
+            follow.
+            This document gives implementation guidelines regarding BACnet [[BACnet]], a building automation and control
+            networking protocol.
         </p>
         <p>
-            More specifically, this document defines a set of vocabulary terms that can be used inside a Thing Description document,
+            More specifically, this document defines a set of vocabulary terms that can be used inside a Thing
+            Description document,
             and associated rules that allow to describe WoT operations using BACnet over the network.
-            Additionally, relevant examples are provided to showcase different vocabulary terms and the associated behavior.
+            Additionally, relevant examples are provided to showcase different vocabulary terms and the associated
+            behavior.
         </p>
     </section>
     <section id='sotd'>
@@ -103,7 +107,8 @@
             detection systems.
         </p>
         <p>
-            This document describes how the Web of Things Thing Description [[WOT-THING-DESCRIPTION]] (TD) can be used to represent devices that use BACnet. 
+            This document describes how the Web of Things Thing Description [[WOT-THING-DESCRIPTION]] (TD) can be used
+            to represent devices that use BACnet.
             In particular, the document explains how to create valid TD Forms for the
             different operations that BACnet can perform.
         </p>
@@ -126,14 +131,14 @@
         </p>
         <p>
             The following subset of BACnet features is supported by this binding:
-            <ul>
-                <li>
-                    Services: ReadProperty, WriteProperty, SubscribeCOV
-                </li>
-                <li>
-                    Data Model: Device, Object, Property, Index
-                </li>
-            </ul>
+        <ul>
+            <li>
+                Services: ReadProperty, WriteProperty, SubscribeCOV
+            </li>
+            <li>
+                Data Model: Device, Object, Property, Index
+            </li>
+        </ul>
         </p>
         <p>
             This protocol binding is intended to be used to enable web applications
@@ -174,10 +179,14 @@
 
             The additions to Q.8 are as follows:
 
-            <ol>
-                <li>object-type and property-identifier are restricted to their numeric versions and not the registered alphanumeric identifiers, in order to reduce the maintenance overhead when new object-types and property-identifiers are introduced in the BACnet standard.</li>
-                <li>Query components (as per <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.4">RFC 3986 Section 3.4</a>) are added to cover specific needs not covered in Annex Q.8. Current examples are command priority and COV increment.</li>
-            </ol>
+        <ol>
+            <li>object-type and property-identifier are restricted to their numeric versions and not the registered
+                alphanumeric identifiers, in order to reduce the maintenance overhead when new object-types and
+                property-identifiers are introduced in the BACnet standard.</li>
+            <li>Query components (as per <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.4">RFC 3986 Section
+                    3.4</a>) are added to cover specific needs not covered in Annex Q.8. Current examples are command
+                priority and COV increment.</li>
+        </ol>
         </p>
         <section>
             <h3>URI Syntax</h3>
@@ -338,7 +347,8 @@ lowercase = %x61-7A  ; "a" to "z"
             This vocabulary is fully defined in the BACnet ontology published together with this document.
         </p>
         <p class="ednote">
-            Until the JSON-LD context is published, this document will use the  example URI <code>"https://example.org/bacnet"</code>for the context with the prefix <code>"bacv"</code>.
+            Until the JSON-LD context is published, this document will use the example URI
+            <code>"https://example.org/bacnet"</code>for the context with the prefix <code>"bacv"</code>.
         </p>
         <section>
             <h3 id="vocabulary-uri-variables">URI Variables</h3>
@@ -362,7 +372,8 @@ lowercase = %x61-7A  ; "a" to "z"
                     </tr>
                     <tr>
                         <td><code>covIncrement</code></td>
-                        <td>Sets COV increment change for reporting via SubscribeCOVProperty (SubscribeCOV with a property ID)</td>
+                        <td>Sets COV increment change for reporting via SubscribeCOVProperty (SubscribeCOV with a
+                            property ID)</td>
                         <td>optional</td>
                         <td>
                             <a href="https://www.w3.org/2019/wot/json-schema#NumberSchema"><code>number</code></a>
@@ -371,25 +382,31 @@ lowercase = %x61-7A  ; "a" to "z"
                 </tbody>
             </table>
             <p>
-                URI Variables are included in the 'bacnet' URI Scheme and are included in the Protocol Binding to communicate PDU option settings for the BACnet driver to use when sending requests.
+                URI Variables are included in the 'bacnet' URI Scheme and are included in the Protocol Binding to
+                communicate PDU option settings for the BACnet driver to use when sending requests.
             </p>
             <p>
-                The following JSON example shows the usage of the BACnet vocabulary for URI Variables, specifically CommandPriority and CovIncrement. The semantic annotation is optional.
+                The following JSON example shows the usage of the BACnet vocabulary for URI Variables, specifically
+                CommandPriority and CovIncrement. The semantic annotation is optional.
             </p>
             <p>
-                This template could be used to construct the uriVariables element for TD interaction affordances, to enable the application to communicate URI variables to the BACnet driver, using a consistent format according to the schema constraints below.
+                This template could be used to construct the uriVariables element for TD interaction affordances, to
+                enable the application to communicate URI variables to the BACnet driver, using a consistent format
+                according to the schema constraints below.
             </p>
             <p>
-                These variables may be also fixed in the href and not exposed via URI variables, causing the BACnet driver to use a constant value for this parameter.
+                These variables may be also fixed in the href and not exposed via URI variables, causing the BACnet
+                driver to use a constant value for this parameter.
             </p>
             <p>
-                Some aspects were identified as improvement candidates in TD.next, which may result in breaking changes regarding URI variables:
-                <ol>
-                    <li>Showing the link of URI variables to exactly which operations they apply to.</li>
-                    <li>Exposing protocol-related parameters from Form-level instead of InteractionAffordance-level.</li>
-                    <li>Providing a standardized set of parameters.</li>
-                    <li>Having the ability to use parameters also in other places than the href</li>
-                </ol>
+                Some aspects were identified as improvement candidates in TD.next, which may result in breaking changes
+                regarding URI variables:
+            <ol>
+                <li>Showing the link of URI variables to exactly which operations they apply to.</li>
+                <li>Exposing protocol-related parameters from Form-level instead of InteractionAffordance-level.</li>
+                <li>Providing a standardized set of parameters.</li>
+                <li>Having the ability to use parameters also in other places than the href</li>
+            </ol>
             </p>
             <pre id="example-uri-variables" class="example" title="URI Variables Usage in BACnet">
 {
@@ -429,8 +446,11 @@ lowercase = %x61-7A  ; "a" to "z"
                         <td><code>bacv:usesService</code></td>
                         <td>Indicates the BACnet service to use</td>
                         <td>
-                            <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                            <p>(one of <code>"ReadProperty"</code>, <code>"WriteProperty"</code>, <code>"SubscribeCOV"</code>)</p>
+                            <a
+                                href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                            <p>(one of <code>"ReadProperty"</code>, <code>"WriteProperty"</code>,
+                                <code>"SubscribeCOV"</code>)
+                            </p>
                         </td>
                         <td>hctl:Form</td>
                     </tr>
@@ -438,7 +458,8 @@ lowercase = %x61-7A  ; "a" to "z"
                         <td><code>bacv:isISO8601</code></td>
                         <td>This data uses ISO8601 format</td>
                         <td>
-                            <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                            <a
+                                href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
                         </td>
                         <td>bacv:Sequence</td>
                     </tr>
@@ -446,7 +467,8 @@ lowercase = %x61-7A  ; "a" to "z"
                         <td><code>bacv:hasBinaryRepresentation</code></td>
                         <td>Points to the binary representation of the resource</td>
                         <td>
-                            <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                            <a
+                                href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
                             <p>(one of <code>"hex"</code>, <code>"dotted-decimal"</code>, <code>"base64"</code>)</p>
                         </td>
                         <td>bacv:OctetString</td>
@@ -471,7 +493,8 @@ lowercase = %x61-7A  ; "a" to "z"
                         <td><code>bacv:hasFieldName</code></td>
                         <td>Name of a Named Member of a Sequence or Choice</td>
                         <td>
-                            <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                            <a
+                                href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
                         </td>
                         <td>
                             bacv:NamedMember
@@ -481,7 +504,8 @@ lowercase = %x61-7A  ; "a" to "z"
                         <td><code>bacv:hasContextTag</code></td>
                         <td>Context Tag for a Named Member of a Sequence or Choice</td>
                         <td>
-                            <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>boolean</code></a>
+                            <a
+                                href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>boolean</code></a>
                         </td>
                         <td>
                             bacv:NamedMember
@@ -500,7 +524,11 @@ lowercase = %x61-7A  ; "a" to "z"
                     <tr>
                         <td><code>bacv:hasLogicalVal</code></td>
                         <td>Logical Value for a ValueMap</td>
-                        <td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a> or <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean">boolean</a></td>
+                        <td><a
+                                href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                            or <a
+                                href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                            or <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean">boolean</a></td>
                         <td>
                             bacv:ValueMapEntry
                         </td>
@@ -508,7 +536,9 @@ lowercase = %x61-7A  ; "a" to "z"
                     <tr>
                         <td><code>bacv:hasProtocolVal</code></td>
                         <td>Protocol Value for a ValueMap</td>
-                        <td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td>
+                        <td><a
+                                href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                        </td>
                         <td>
                             bacv:ValueMapEntry
                         </td>
@@ -582,7 +612,7 @@ lowercase = %x61-7A  ; "a" to "z"
             <p>
                 BACnet has its own data model, which cannot always be derived
                 from the data schema of the interaction affordances. Hence
-                the type information is amended in the Form (column 3) of the protocol binding while 
+                the type information is amended in the Form (column 3) of the protocol binding while
                 staying conceptually conformant to the WoT Data Schema (column 2).
                 The goal here is to abstract BACnet's data model into a Web-like JSON-based
                 data model, by still keeping the wire compatibility on the protocol.
@@ -619,7 +649,8 @@ lowercase = %x61-7A  ; "a" to "z"
                         <td>
                             <code>{ "type": "object" }</code>
                             <br />
-                            For the special case where a DateTime object is modeled as a Sequence <code>"bacv:isISO8601": true</code>:
+                            For the special case where a DateTime object is modeled as a Sequence
+                            <code>"bacv:isISO8601": true</code>:
                             <br />
                             <code>
                                 {
@@ -993,7 +1024,7 @@ lowercase = %x61-7A  ; "a" to "z"
             property identifier <code>present-value</code> in the scope of a
             BACnet device with device instance number <code>5</code>.
         </p>
-<pre id="example-readproperty" class="example" title="A BACnet property">
+        <pre id="example-readproperty" class="example" title="A BACnet property">
 {
     "@context": ["https://www.w3.org/2022/wot/td/v1.1",
     {
@@ -1017,14 +1048,17 @@ lowercase = %x61-7A  ; "a" to "z"
 }
 </pre>
 
-<p>
-    [[[#example-uri-variables-with-forms]]] demonstrates how the <code>uriVariables</code> in the affordance-level can be 
-    used and how they need to be represented in a <code>forms</code> element.
-    The <code>"bacv:covIncrement"</code> indicates that the URI variable set by the Consumer application will be used to notify the 
-    Consumer only if the property value changes more than the set amount by the URI variable. 
-</p>
+        <p>
+            [[[#example-uri-variables-with-forms]]] demonstrates how the <code>uriVariables</code> in the
+            affordance-level can be
+            used and how they need to be represented in a <code>forms</code> element.
+            The <code>"bacv:covIncrement"</code> indicates that the URI variable set by the Consumer application will be
+            used to notify the
+            Consumer only if the property value changes more than the set amount by the URI variable.
+        </p>
 
-<pre id="example-uri-variables-with-forms" class="example" title="uriVariables in the Affordance Level with Associated forms">
+        <pre id="example-uri-variables-with-forms" class="example"
+            title="uriVariables in the Affordance Level with Associated forms">
 {
     "@context": ["https://www.w3.org/2022/wot/td/v1.1",
     {
@@ -1055,12 +1089,13 @@ lowercase = %x61-7A  ; "a" to "z"
 }
 </pre>
 
-<p>
-    [[[#example-enum-mapping]]] shows how an <code>enum</code> in the Data Schema is extended in the <code>forms</code> 
-    to make it understandable by BACnet drivers.
-</p>
+        <p>
+            [[[#example-enum-mapping]]] shows how an <code>enum</code> in the Data Schema is extended in the
+            <code>forms</code>
+            to make it understandable by BACnet drivers.
+        </p>
 
-<pre id="example-enum-mapping" class="example" title="Enum Mapping for BACnet Types">
+        <pre id="example-enum-mapping" class="example" title="Enum Mapping for BACnet Types">
 {
     "@context": ["https://www.w3.org/2022/wot/td/v1.1",
     {

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -171,6 +171,13 @@
         <p>
             The 'bacnet' URI Scheme used herein is based on the definition in Annex Q.8 of
             the BACnet Specification [[BACnet]].
+
+            The additions to Q.8 are as follows:
+
+            <ol>
+                <li>object-type and property-identifier are restricted to their numeric versions and not the registered alphanumeric identifiers, in order to reduce the maintenance overhead when new object-types and property-identifiers are introduced in the BACnet standard.</li>
+                <li>Query components (as per <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.4">RFC 3986 Section 3.4</a>) are added to cover specific needs not covered in Annex Q.8. Current examples are command priority and COV increment.</li>
+            </ol>
         </p>
         <section>
             <h3>URI Syntax</h3>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1090,6 +1090,63 @@ lowercase = %x61-7A  ; "a" to "z"
 </pre>
 
         <p>
+            [[[#example-uri-variable-for-writing]]] demonstrates how the <code>uriVariable</code> in the
+            affordance-level can be used to model a writing priority in a <code>forms</code> element.
+            The <code>"bacv:commandPriority"</code> indicates that the URI variable set by the Consumer application will
+            used relayed as the priority argument in the WriteProperty request.
+            For other operations (readproperty, observeproperty, unobserveproperty) this URI variable is irrelevant, so the corresponding forms do not use the URI variable.
+            If the URI variable is also irrelevant for the writeproperty operation (e.g. in case the BACnet object doesn't have a priority array),
+            it can also be left out of the writeproperty form and the URI variable can be omitted completely.
+            The URI variable comes with a default, so in case the Consumer doesn't provide this URI variable, the default of 16 will be used.
+            Another possibility is to fix the writing priority in the TD by giving a fixed commandPriority in the href of the form, and not exposing its value via a URI variable.
+            These decisions belong to the TD author.
+        </p>
+
+        <pre id="example-uri-variable-for-writing" class="example"
+            title="uriVariables in the Affordance Level for writing">
+            {
+                "@context": ["https://www.w3.org/2022/wot/td/v1.1",
+                {
+                    "bacv": "https://example.org/bacnet"
+                }],
+                ...
+                "properties": {
+                    "analog1": {
+                        "type": "number",
+                        "readOnly": false,
+                        "writeOnly": false,
+                        "observable": true,
+                        "uriVariables": {
+                            "writePriority": {
+                                "@type": "bacv:commandPriority",
+                                "type": "integer",
+                                "enum": [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+                                "default": 16
+                            }
+                        },
+                        "forms": [
+                            {
+                                "op": [ "readproperty", "observeproperty", "unobserveproperty" ],
+                                "href": "bacnet://5/2,1",
+                                "bacv:hasDataType": {
+                                    "@type": "bacv:Real"
+                                }
+                            },
+                            {
+                                "op": [ "writeproperty" ],
+                                "href": "bacnet://5/2,1?commandPriority={writePriority}",
+                                "bacv:usesService": "WriteProperty",
+                                "bacv:hasDataType": {
+                                    "@type": "bacv:Real"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+</pre>
+
+        <p>
             [[[#example-enum-mapping]]] shows how an <code>enum</code> in the Data Schema is extended in the
             <code>forms</code>
             to make it understandable by BACnet drivers.

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -949,16 +949,7 @@ lowercase = %x61-7A  ; "a" to "z"
                     <tr>
                         <td><code>bacv:Any</code></td>
                         <td>
-                            <code>
-                                { "anyOf": [
-                                    { "type": "object" },
-                                    { "type": "array" },
-                                    { "type": "number" },
-                                    { "type": "string" },
-                                    { "type": "boolean" },
-                                    { "type": "null" }
-                                ]}
-                            </code>
+                            The <code>type</code> field should be left out completely. This is allowed according to <a href="https://www.w3.org/TR/wot-thing-description/#sec-data-schema-vocabulary-definition">WoT Data Schema Vocabulary Definitions</a>.
                         </td>
                         <td>
                             <code>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1084,7 +1084,7 @@ lowercase = %x61-7A  ; "a" to "z"
             [[[#example-uri-variable-for-writing]]] demonstrates how the <code>uriVariable</code> in the
             affordance-level can be used to model a writing priority in a <code>forms</code> element.
             The <code>"bacv:commandPriority"</code> indicates that the URI variable set by the Consumer application will
-            used relayed as the priority argument in the WriteProperty request.
+            be relayed as the priority argument in the WriteProperty request.
             For other operations (readproperty, observeproperty, unobserveproperty) this URI variable is irrelevant, so the corresponding forms do not use the URI variable.
             If the URI variable is also irrelevant for the writeproperty operation (e.g. in case the BACnet object doesn't have a priority array),
             it can also be left out of the writeproperty form and the URI variable can be omitted completely.

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1086,9 +1086,9 @@ lowercase = %x61-7A  ; "a" to "z"
             The <code>"bacv:commandPriority"</code> indicates that the URI variable set by the Consumer application will
             be relayed as the priority argument in the WriteProperty request.
             For other operations (readproperty, observeproperty, unobserveproperty) this URI variable is irrelevant, so the corresponding forms do not use the URI variable.
-            If the URI variable is also irrelevant for the writeproperty operation (e.g. in case the BACnet object doesn't have a priority array),
+            If the URI variable is also irrelevant for the writeproperty operation (e.g., when the BACnet object doesn't have a priority array),
             it can also be left out of the writeproperty form and the URI variable can be omitted completely.
-            The URI variable comes with a default, so in case the Consumer doesn't provide this URI variable, the default of 16 will be used.
+            The URI variable comes with a default, so if the Consumer doesn't provide this URI variable, the default of 16 will be used.
             Another possibility is to fix the writing priority in the TD by giving a fixed commandPriority in the <code>href</code> of the form, and not exposing its value via a URI variable.
             These decisions belong to the TD author.
         </p>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1089,7 +1089,7 @@ lowercase = %x61-7A  ; "a" to "z"
             If the URI variable is also irrelevant for the writeproperty operation (e.g. in case the BACnet object doesn't have a priority array),
             it can also be left out of the writeproperty form and the URI variable can be omitted completely.
             The URI variable comes with a default, so in case the Consumer doesn't provide this URI variable, the default of 16 will be used.
-            Another possibility is to fix the writing priority in the TD by giving a fixed commandPriority in the href of the form, and not exposing its value via a URI variable.
+            Another possibility is to fix the writing priority in the TD by giving a fixed commandPriority in the <code>href</code> of the form, and not exposing its value via a URI variable.
             These decisions belong to the TD author.
         </p>
 


### PR DESCRIPTION
Hi @egekorkan @ektrah @mjkoster 

Here few improvements for the BACnet protocol binding:

1. The two differences to URI schema in BACnet's Annex Q.8 are listed explicitly -> this is in order to give a concrete idea what the current minimal differences are.
2. Add an example for writing -> was a request by Coleman Brumley back in Feb 2024
3. Change the any model to omit the type field in the WoT data schema. -> it's allowed and it's more correct to cover more complex cases like Variants etc.
4. Auto-format the HTML -> better indentation etc.
5. Use bacv: instead of bacnet: in ttl -> make it consistent with the HTML and JSON schema

I distributed the changes to commits, so should be able to review each change on its own.