### PR TITLE
BACnet support for events

### DIFF
--- a/bindings/protocols/bacnet/bacnet-model.ttl
+++ b/bindings/protocols/bacnet/bacnet-model.ttl
@@ -72,7 +72,7 @@ Default BACnet service by td:OperationType:
 - td:unsubscribeEvent -> RemoveListElement (will always be to the Recipient-List property of the Notification-Class object)
 TODO: Can we specify the defaults in a machine-readable, RDF-standard way?
 
-No defaults are specified for the following, TD must specify the service explicitly for them:
+No defaults are specified for the following; TD must specify the service explicitly for them:
 - td:invokeAction, td:queryAction, td:cancelAction
 - td:readAllProperties, td:writeAllProperties, td:readMultipleProperties, td:writeMultipleProperties, td:observeAllProperties, td:unobserveAllProperties
 - td:queryAllActions

--- a/bindings/protocols/bacnet/bacnet-model.ttl
+++ b/bindings/protocols/bacnet/bacnet-model.ttl
@@ -53,19 +53,27 @@ Additional parameters can be specified via URI variable syntax, e.g. ?commandPri
 
 bacv:usesService rdf:type owl:DatatypeProperty ;
                    rdfs:domain hctl:Form ;
-                   rdfs:range [owl:oneOf ("ReadProperty"^^xsd:string "WriteProperty"^^xsd:string "SubscribeCOV"^^xsd:string)] ;
+                   rdfs:range [owl:oneOf (
+                        "ReadProperty"^^xsd:string
+                        "WriteProperty"^^xsd:string
+                        "SubscribeCOV"^^xsd:string
+                        "GetEventInfo"^^xsd:string
+                        "AcknowledgeAlarm"^^xsd:string
+                        "AddListElement"^^xsd:string
+                        "RemoveListElement"^^xsd:string
+                    )] ;
                    rdfs:comment """
 Default BACnet service by td:OperationType:
 - td:readProperty -> ReadProperty
 - td:writeProperty -> WriteProperty
 - td:observeProperty -> SubscribeCOV, subscribe to object if no property ID is present in target, otherwise subscribe to property
 - td:unobserveProperty -> SubscribeCOV (will do an unsubscribe instead)
-
+- td:subscribeEvent -> AddListElement (will always be to the Recipient-List property of the Notification-Class object)
+- td:unsubscribeEvent -> RemoveListElement (will always be to the Recipient-List property of the Notification-Class object)
 TODO: Can we specify the defaults in a machine-readable, RDF-standard way?
 
-Not mapped yet:
+No defaults are specified for the following, TD must specify the service explicitly for them:
 - td:invokeAction, td:queryAction, td:cancelAction
-- td:subscribeEvent, td:unsubscribeEvent
 - td:readAllProperties, td:writeAllProperties, td:readMultipleProperties, td:writeMultipleProperties, td:observeAllProperties, td:unobserveAllProperties
 - td:queryAllActions
 - td:subscribeAllEvents, td:unsubscribeAllEvents

--- a/bindings/protocols/bacnet/bacnet.schema.json
+++ b/bindings/protocols/bacnet/bacnet.schema.json
@@ -248,7 +248,62 @@
             "enum": [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             "default": 16
         },
-        "action_input_getEventInfoInput": {
+        "eventPayload": {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "format": "iri-reference"
+              },
+              "time": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "prio": {
+                "type": "integer"
+              },
+              "message": {
+                "type": "string"
+              },
+              "ackReq": {
+                "type": "integer",
+                "enum": [0, 1],
+                "default": 0
+              },
+              "toState": {
+                "type": "string",
+                "enum": [
+                  "fault",
+                  "offnormal",
+                  "normal"
+                ]
+              },
+              "eventType": {
+                "type": "string",
+                "enum": ["regular", "ack", "syncrequired"],
+                "default": "regular"
+              },
+              "origSource": {
+                "type": "string",
+                "format": "iri-reference"
+              },
+              "values": {
+                "type": "object"
+              },
+              "inactive": {
+                "type": "integer",
+                "enum": [0, 1],
+                "default": 0
+              }
+            },
+            "required": [
+              "source",
+              "time",
+              "prio",
+              "toState"
+            ]
+        },
+        "action_input_getCurrentEvents": {
             "$comment": "This is not part of the form, but should be used in ActionAffordance.input BACnet GetEventInfo",
             "type": "object",
             "properties": {
@@ -258,66 +313,14 @@
               }
             }
         },
-        "action_output_getEventInfo": {
+        "action_output_getCurrentEvents": {
             "$comment": "This is not part of the form, but should be used in ActionAffordance.output BACnet GetEventInfo",
             "type": "object",
             "properties": {
               "currentEvents": {
                 "type": "array",
                 "items": {
-                  "type": "object",
-                  "properties": {
-                    "source": {
-                      "type": "string",
-                      "format": "iri-reference"
-                    },
-                    "time": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "prio": {
-                      "type": "integer"
-                    },
-                    "ackReq": {
-                      "type": "integer",
-                      "enum": [0, 1],
-                      "default": 0
-                    },
-                    "toState": {
-                      "type": "string",
-                      "enum": [
-                        "fault",
-                        "offnormal",
-                        "normal"
-                      ]
-                    },
-                    "eventType": {
-                      "type": "string",
-                      "enum": ["regular", "ack", "syncrequired"],
-                      "default": "regular"
-                    },
-                    "origSource": {
-                      "type": "string",
-                      "format": "iri-reference"
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "values": {
-                      "type": "object"
-                    },
-                    "inactive": {
-                      "type": "integer",
-                      "enum": [0, 1],
-                      "default": 0
-                    }
-                  },
-                  "required": [
-                    "source",
-                    "time",
-                    "prio",
-                    "toState"
-                  ]
+                  "$ref": "#/definitions/eventPayload"
                 }
               }
             },
@@ -329,7 +332,7 @@
               "moreEvents"
             ]
         },
-        "action_input_acknowledgeAlarm": {
+        "action_input_acknowledgeEvent": {
             "$comment": "This is not part of the form, but should be used in ActionAffordance.input BACnet AcknowledgeAlarm",
             "type": "object",
             "properties": {
@@ -376,59 +379,7 @@
         },
         "event_data": {
             "$comment": "This is not part of the form, but should be used in EventAffordance.data for BACnet events",
-            "type": "object",
-            "properties": {
-              "source": {
-                "type": "string",
-                "format": "iri-reference"
-              },
-              "time": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "prio": {
-                "type": "integer"
-              },
-              "ackReq": {
-                "type": "integer",
-                "enum": [0, 1],
-                "default": 0
-              },
-              "toState": {
-                "type": "string",
-                "enum": [
-                  "fault",
-                  "offnormal",
-                  "normal"
-                ]
-              },
-              "eventType": {
-                "type": "string",
-                "enum": ["regular", "ack", "syncrequired"],
-                "default": "regular"
-              },
-              "origSource": {
-                "type": "string",
-                "format": "iri-reference"
-              },
-              "message": {
-                "type": "string"
-              },
-              "values": {
-                "type": "object"
-              },
-              "inactive": {
-                "type": "integer",
-                "enum": [0, 1],
-                "default": 0
-              }
-            },
-            "required": [
-              "source",
-              "time",
-              "prio",
-              "toState"
-            ]
+            "$ref": "#/definitions/eventPayload"
         }
     },
     "type": "object",

--- a/bindings/protocols/bacnet/bacnet.schema.json
+++ b/bindings/protocols/bacnet/bacnet.schema.json
@@ -15,14 +15,17 @@
                     "enum": [
                         "ReadProperty",
                         "WriteProperty",
-                        "SubscribeCOV"
+                        "SubscribeCOV",
+                        "GetEventInfo",
+                        "AcknowledgeAlarm",
+                        "AddListElement",
+                        "RemoveListElement"
                     ]
                 },
                 "bacv:hasDataType": {
                     "$ref": "#/definitions/bacnetDataType"
                 }
-            },
-            "required": ["bacv:hasDataType"]
+            }
         },
         "bacnetDataType": {
             "oneOf": [
@@ -245,6 +248,118 @@
             "enum": [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             "default": 16
         },
+        "action_input_getEventInfoInput": {
+            "$comment": "This is not part of the form, but should be used in ActionAffordance.input BACnet GetEventInfo",
+            "type": "object",
+            "properties": {
+              "lastReceivedSource": {
+                "type": "string",
+                "fomat": "iri-reference"
+              }
+            }
+        },
+        "action_output_getEventInfo": {
+            "$comment": "This is not part of the form, but should be used in ActionAffordance.output BACnet GetEventInfo",
+            "type": "object",
+            "properties": {
+              "currentEvents": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "source": {
+                      "type": "string",
+                      "format": "iri-reference"
+                    },
+                    "time": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "prio": {
+                      "type": "integer"
+                    },
+                    "ackReq": {
+                      "type": "integer",
+                      "enum": [0, 1],
+                      "default": 0
+                    },
+                    "toState": {
+                      "type": "string",
+                      "enum": [
+                        "fault",
+                        "offnormal",
+                        "normal"
+                      ]
+                    },
+                    "eventType": {
+                      "type": "string",
+                      "enum": ["regular", "ack", "syncrequired"],
+                      "default": "regular"
+                    },
+                    "origSource": {
+                      "type": "string",
+                      "format": "iri-reference"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "values": {
+                      "type": "object"
+                    },
+                    "inactive": {
+                      "type": "integer",
+                      "enum": [0, 1],
+                      "default": 0
+                    }
+                  },
+                  "required": [
+                    "source",
+                    "time",
+                    "prio",
+                    "toState"
+                  ]
+                }
+              }
+            },
+            "moreEvents": {
+              "type": "boolean"
+            },
+            "required": [
+              "currentEvents",
+              "moreEvents"
+            ]
+        },
+        "action_input_acknowledgeAlarm": {
+            "$comment": "This is not part of the form, but should be used in ActionAffordance.input BACnet AcknowledgeAlarm",
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "format": "iri-reference"
+                  },
+                  "toState": {
+                    "$comment": "The state being acknowledged",
+                    "type": "string",
+                    "enum": [
+                      "fault",
+                      "offnormal",
+                      "normal"
+                    ]
+                  },
+                  "eventTime": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "ackSource": {
+                    "type": "string"
+                  },
+                  "ackTime": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "required": ["source", "ackState", "eventTime", "ackSource", "ackTime"]
+            }
+        },
         "affordance": {
             "type": "object",
             "additionalProperties": {
@@ -258,6 +373,62 @@
                     }
                 }
             }
+        },
+        "event_data": {
+            "$comment": "This is not part of the form, but should be used in EventAffordance.data for BACnet events",
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "format": "iri-reference"
+              },
+              "time": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "prio": {
+                "type": "integer"
+              },
+              "ackReq": {
+                "type": "integer",
+                "enum": [0, 1],
+                "default": 0
+              },
+              "toState": {
+                "type": "string",
+                "enum": [
+                  "fault",
+                  "offnormal",
+                  "normal"
+                ]
+              },
+              "eventType": {
+                "type": "string",
+                "enum": ["regular", "ack", "syncrequired"],
+                "default": "regular"
+              },
+              "origSource": {
+                "type": "string",
+                "format": "iri-reference"
+              },
+              "message": {
+                "type": "string"
+              },
+              "values": {
+                "type": "object"
+              },
+              "inactive": {
+                "type": "integer",
+                "enum": [0, 1],
+                "default": 0
+              }
+            },
+            "required": [
+              "source",
+              "time",
+              "prio",
+              "toState"
+            ]
         }
     },
     "type": "object",

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1018,8 +1018,9 @@ lowercase = %x61-7A  ; "a" to "z"
                         to the same Notification Class. In the typical case, a client will register to all Notification Classes of a BACnet Device.
                     </li>
                     <li>
-                        Some alarms can be configured as acknowledgement required. Acknowledgement is defined by BACnet as a manual action
+                        Some alarms can be configured as "acknowledgement required". Acknowledgement is defined by BACnet as a manual action
                         performed by a human operator, and is separate from the confirmation of the successful reception of the event notification.
+
                     </li>
                 </ol>
                 The picture below demonstrates these key aspects and how they are mapped to the WoT concepts.

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1126,13 +1126,13 @@ lowercase = %x61-7A  ; "a" to "z"
                                 <li>source: IRI of the BACnet object sending the event</li>
                                 <li>time: Timestamp of the event</li>
                                 <li>prio: Priority of the event</li>
-                                <li>ackReq (optional): Flag indicating if acknowledge is required. Default is false.</li>
+                                <li>ackReq (optional): Flag indicating whether acknowledgement is required. Default is false.</li>
                                 <li>toState: The target state of the event transition</li>
                                 <li>origSource (optional): In case of algorithmic reporting, the IRI of the object monitored by the event-sending object.</li>
-                                <li>eventType (optional): If the event is a regular event transition, an acknowledge notification or a general sync-required event. Default is regular.</li>
+                                <li>eventType (optional): If the event is a regular event transition, an acknowledgement notification or a general sync-required event. Default is regular.</li>
                                 <li>values (optional): Additional values associated with the event, e.g. high-limit in case the value exceeded an OffNormal limit.</li>
                                 <li>message (optional): The message associated with the event.</li>
-                                <li>inactive (optional): Flag if the event is not active anymore, default is false. This is needed for inactive, but not yet acknowledged events; they are there for symmetry with GetCurrentEvents action.</li>
+                                <li>inactive (optional): Flag whether the event is not active anymore. Default is false. This is needed for inactive, but not yet acknowledged events; they are there for symmetry with GetCurrentEvents action.</li>
                             </ul>
                         </td>
                         <td>
@@ -1190,7 +1190,7 @@ lowercase = %x61-7A  ; "a" to "z"
                                         <li>inactive (optional)</li>
                                     </ul>
                                 </li>
-                                <li>moreEvents: Flag indicating if more events should be queried</li>
+                                <li>moreEvents: Flag indicating whether more events should be queried</li>
                             </ul>
                         </td>
                         <td>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1029,9 +1029,10 @@ lowercase = %x61-7A  ; "a" to "z"
             <p>
                 The key aspects of the mapping to WoT are:
                 <ol>
-                    <li>Each Notification Class is mapped to an EventAffordance. This maps to the subscription granularity directly.</li>
-                    <li>Event Enrollment objects used for algorithmic reporting are not mapped explicitly, they are per se not relevant to the WoT consumer.</li>
-                    <li>Special event-related actions are mapped to ActionAffordances: getting current events and acknowledging events.</li>
+                    <li>Each Notification Class is mapped to an EventAffordance. This maps directly to the subscription granularity.</li>
+                    <li>Event Enrollment objects used for algorithmic reporting are not explicitly mapped; they are not relevant to the WoT consumer, per se.</li>
+                    <li>Special event-related actions (getting current events and acknowledging events) are mapped to ActionAffordances.</li>
+
                     <li>
                         Thing is assumed to be mapped to the BACnet device. While this is simple, it is not a mandatory decision.
                         In specific cases, one BACnet device can correspond to multiple things, and even vice-versa.

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1206,9 +1206,9 @@ lowercase = %x61-7A  ; "a" to "z"
                             </ul>
                         </td>
                         <td>
-                            As indicated above, the BACnet payload and the ActionAffordance output differ especially around how events are grouped.
-                            In the BACnet payload, one list item represents one object with its three possible events, which is reflected in Event State, Acknowledged Transitions, Event Timestamps and Priorities.
-                            This is to be processed and split into one standalone event for every current event of this object, or past unacknowledged event, with corresponding timestamp, priority...
+                            As indicated above, the BACnet payload and the ActionAffordance output differ, especially around how events are grouped.
+                            In the BACnet payload, one list item represents one object with its three possible events, which is reflected in Event State, Acknowledged Transitions, Event Timestamps, and Priorities.
+                            This is to be processed and split into one standalone event for every current event, or past unacknowledged event, of this object, with corresponding timestamp, priority, etc.
                         </td>
                     </tr>
                     <tr>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1126,13 +1126,13 @@ lowercase = %x61-7A  ; "a" to "z"
                                 <li>source: IRI of the BACnet object sending the event</li>
                                 <li>time: Timestamp of the event</li>
                                 <li>prio: Priority of the event</li>
-                                <li>ackReq (opt.): Flag indicating if acknowledge is required. Default is false.</li>
+                                <li>ackReq (optional): Flag indicating if acknowledge is required. Default is false.</li>
                                 <li>toState: The target state of the event transition</li>
-                                <li>origSource (opt.): In case of algorithmic reporting, the IRI of the object monitored by the event-sending object.</li>
-                                <li>eventType (opt.): If the event is a regular event transition, an acknowledge notification or a general sync-required event. Default is regular.</li>
-                                <li>values (opt.): Additional values associated with the event, e.g. high-limit in case the value exceeded an OffNormal limit.</li>
-                                <li>message (opt.): The message associated with the event.</li>
-                                <li>inactive (opt.): Flag if the event is not active anymore, default is false. This is needed for inactive, but not yet acknowledged events; they are there for symmetry with GetCurrentEvents action.</li>
+                                <li>origSource (optional): In case of algorithmic reporting, the IRI of the object monitored by the event-sending object.</li>
+                                <li>eventType (optional): If the event is a regular event transition, an acknowledge notification or a general sync-required event. Default is regular.</li>
+                                <li>values (optional): Additional values associated with the event, e.g. high-limit in case the value exceeded an OffNormal limit.</li>
+                                <li>message (optional): The message associated with the event.</li>
+                                <li>inactive (optional): Flag if the event is not active anymore, default is false. This is needed for inactive, but not yet acknowledged events; they are there for symmetry with GetCurrentEvents action.</li>
                             </ul>
                         </td>
                         <td>
@@ -1161,7 +1161,7 @@ lowercase = %x61-7A  ; "a" to "z"
                         <td>GetCurrentEvents: ActionAffordance.input</td>
                         <td>
                             <ul>
-                                <li>lastReceivedSource (opt.): IRI of the last received object with event</li>
+                                <li>lastReceivedSource (optional): IRI of the last received object with event</li>
                             </ul>
                         </td>
                         <td>
@@ -1181,13 +1181,13 @@ lowercase = %x61-7A  ; "a" to "z"
                                         <li>source</li>
                                         <li>time</li>
                                         <li>prio</li>
-                                        <li>ackReq (opt.)</li>
+                                        <li>ackReq (optional)</li>
                                         <li>toState</li>
-                                        <li>origSource (opt.)</li>
-                                        <li>eventType (opt.)</li>
-                                        <li>values (opt.)</li>
-                                        <li>message (opt.)</li>
-                                        <li>inactive (opt.)</li>
+                                        <li>origSource (optional)</li>
+                                        <li>eventType (optional)</li>
+                                        <li>values (optional)</li>
+                                        <li>message (optional)</li>
+                                        <li>inactive (optional)</li>
                                     </ul>
                                 </li>
                                 <li>moreEvents: Flag indicating if more events should be queried</li>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1013,9 +1013,10 @@ lowercase = %x61-7A  ; "a" to "z"
                         or dedicated other objects can monitor other objects (algorithmic reporting)
                     </li>
                     <li>
-                        Alarms are always sent via Notification Class objects, which keep lists of alarm recipients, i.e. alarm subscriptions
-                        are always done to the Notification Classes, it is not possible to receive alarms only from some of the objects linked
-                        to the same Notification Class. In the typical case, a client will register to all Notification Classes of a BACnet Device.
+                        Alarms are always sent via Notification Class objects, which keep lists of alarm recipients, i.e., alarm subscriptions
+                        are always of the Notification Classes; it is not possible to receive alarms only from some of the objects linked
+                        to a given Notification Class. In the typical case, a client will register to all Notification Classes of a BACnet Device.
+
                     </li>
                     <li>
                         Some alarms can be configured as "acknowledgement required". Acknowledgement is defined by BACnet as a manual action
@@ -1113,7 +1114,8 @@ lowercase = %x61-7A  ; "a" to "z"
                     </tr>
                     <tr>
                         <td>EventAffordance.cancellation</td>
-                        <td>Not modeled, cancellation is implicit</td>
+                        <td>Not modeled; cancellation is implicit</td>
+
                         <td>Same as EventAffordance.subscription</td>
                         <td>Same as EventAffordance.subscription</td>
                     </tr>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1664,11 +1664,7 @@ lowercase = %x61-7A  ; "a" to "z"
         </pre>
 
         <p>
-            The resulting example payloads are available below. [[[#example-event-data]]] shows an event notification.
-            [[[#example-acknowledgeevent-input]]] shows what a WoT Consumer would send for acknowledging this event.
-            And [[[#example-getcurrentevents-output]]] shows the same alarm and another alarm that happened before in the
-            GetCurrentEvents action's output, note that in the second alarm <code>ackReq</code> value turned to 0,
-            because now this event was acknowledged.
+            The resulting example payloads are available below.
         </p>
 
         <pre id="example-event-data" class="example" title="Example event data">
@@ -1688,6 +1684,15 @@ lowercase = %x61-7A  ; "a" to "z"
             }
         </pre>
 
+        <p>
+            [[[#example-event-data]]] shows an event notification because of an overheating equipment. Event <code>message</code>
+            gives this as a useful hint, <code>prio</code> is set accordingly. <code>values</code> object gives additional details
+            about the event that the current value is 55 and the exceeded limit was 50. The unit of these values can be found at the
+            <code>source</code> object that triggered this event.
+            Because overheating events are important for the operator to notice, <code>ackReq</code> is set, so the operator definitely
+            will see the event, even after the overheating condition is over.
+        </p>
+
         <pre id="example-acknowledgeevent-input" class="example" title="Example AcknowledgeEvent input">
             {
                 "source": "bacnet://5/0,20",
@@ -1698,6 +1703,11 @@ lowercase = %x61-7A  ; "a" to "z"
             }
         </pre>
 
+        <p>
+            When the operator sees this event and decides to acnowledge it, management station will send the payload shown in
+            [[[#example-acknowledgeevent-input]]]. This can happen before or after the event is over.
+        </p>
+        
         <pre id="example-getcurrentevents-output" class="example" title="Example GetCurrentEvents output">
             {
                 "currentEvents": [
@@ -1726,6 +1736,14 @@ lowercase = %x61-7A  ; "a" to "z"
                 "moreEvents": false
             }
         </pre>
+
+        <p>
+            If the event client wants to get a list of all events of the device, it will invoke the GetCurrentEvents action, and will receive
+            te payload shown in [[[#example-getcurrentevents-output]]]. Here the event notification about the overheating and a past fault event can be
+            seen. This is useful for synchronizing the events known on the client to the events that are on the device, in case of temporary
+            disconnection, reboot of client or device etc. Please note that in the second alarm <code>ackReq</code> value turned to 0,
+            because this event was acknowledged by the operator in the meantime.
+        </p>
 
     </section>
 </body>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1042,11 +1042,12 @@ lowercase = %x61-7A  ; "a" to "z"
             </p>
             <p>
                 In contrast to PropertyAffordances, which are generically mapped to BACnet,
-                interactions related to events come with a specific payload specified by the BACnet standard. The flexibility that would be for example possible
-                for an HTTP longpoll-based event notification with a custom HTTP body is not possible in BACnet context.
+                interactions related to events come with a specific payload specified by the BACnet standard. The flexibility that would be possible, for example,
+                for an HTTP longpoll-based event notification with a custom HTTP body, is not possible in BACnet context.
                 Thus, it is necessary for the WoT consumer to work with a given logical data schema that is influenced by the BACnet standard.
-                Still, this binding takes an approach to define the data schemata of the InteractionAffordances as independent as possible from BACnet, in
-                order to avoid a direct dependency of WoT consumers to a specific protocol.
+                Still, this binding takes an approach to define the data schemata of the InteractionAffordances as independently as possible from BACnet, in
+                order to avoid a direct dependency of WoT consumers on a specific protocol.
+
             </p>
             <p>
                 With this background, this binding takes some simplifying design decisions:

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1035,9 +1035,10 @@ lowercase = %x61-7A  ; "a" to "z"
                     <li>
                         Special event-related actions (getting current events and acknowledging events) are mapped to ActionAffordances.
                         <div class="note">
-                            <p>The WoT consumer does not need to know the details of BACnet alarming, it can simply interact with the InteractionAffordances of the Thing,
-                            as per their data schemata. However the consumer still needs to have an implicit understanding about the relations
+                            <p>The WoT consumer does not need to know the details of BACnet alarming; it can simply interact with the InteractionAffordances of the Thing,
+                            according to their data schemata. However, the consumer does need to have an understanding of the relations
                             between the InteractionAffordances:</p>
+
                             <ol>
                                 <li>
                                     <code>GetCurrentEvents</code> action can be used to fetch all current events of the thing, which would not be received
@@ -1148,7 +1149,8 @@ lowercase = %x61-7A  ; "a" to "z"
                                 <li>toState: The target state of the event transition</li>
                                 <li>origSource (optional): In case of algorithmic reporting, the IRI of the object monitored by the event-sending object.</li>
                                 <li>eventType (optional): If the event is a regular event transition, an acknowledgement notification or a general sync-required event. Default is regular.</li>
-                                <li>values (optional): Additional values associated with the event, e.g. high-limit in case the value exceeded an OffNormal limit.</li>
+                                <li>values (optional): Additional values associated with the event, e.g., high-limit if the value exceeded an OffNormal limit.</li>
+
                                 <li>message (optional): The message associated with the event.</li>
                                 <li>inactive (optional): Flag whether the event is not active anymore. Default is false. This is needed for inactive, but not yet acknowledged events; they are there for symmetry with GetCurrentEvents action.</li>
                             </ul>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1000,7 +1000,8 @@ lowercase = %x61-7A  ; "a" to "z"
             <p>
                 BACnet has an extensive alarm model; see [[BACnet]] Chapter 13. Alarm and Event Services for a complete description.
 
-                The fundamental aspects are:
+                The fundamental aspects are as follows:
+
                 <ol>
                     <li>
                         There are three event states: Normal (no event); OffNormal (e.g., operating temperature outside of the normal range);

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -995,6 +995,246 @@ lowercase = %x61-7A  ; "a" to "z"
                 </tbody>
             </table>
         </section>
+        <section id="event-mappings">
+            <h3>Mappings related to events</h3>
+            <p>
+                BACnet has an extensive event model, see [[BACnet]] Chapter 13. Alarm and Event Services for a complete description.
+                The fundamental aspects are:
+                <ol>
+                    <li>
+                        There are three event states: Normal (no event), OffNormal (e.g. operating temperature outside of the normal range)
+                        and Fault (e.g. defect sensor). Events are sent in case of transitions, including self-transitions and toNormal transitions.
+                    </li>
+                    <li>
+                        Objects can monitor themselves for event states (intrinsic reporting),
+                        or dedicated other objects can monitor other objects (algorithmic reporting)
+                    </li>
+                    <li>
+                        Alarms are always sent via Notification Class objects, which keep lists of alarm recipients, i.e. event subscriptions
+                        are always done to the Notification Classes, it is not possible to receive events only from some of the objects linked
+                        to the same Notification Class.
+                    </li>
+                </ol>
+                The picture below demonstrates these key aspects and how they are mapped to the WoT concepts.
+            </p>
+            <img src="../../../images/bacnet_events.drawio.svg" alt="BACnet Eventing Overview and its mapping to WoT" />
+            <p>
+                The key aspects of the mapping to WoT are:
+                <ol>
+                    <li>Each Notification Class is mapped to an EventAffordance. This maps to the subscription granularity directly.</li>
+                    <li>Event Enrollment objects used for algorithmic reporting are not mapped explicitly, they are per se not relevant to the WoT consumer.</li>
+                    <li>Special event-related actions are mapped to ActionAffordances: getting current events and acknowledging events.</li>
+                    <li>
+                        Thing is assumed to be mapped to the BACnet device. While this is simple, it is not a mandatory decision.
+                        In specific cases one BACnet device can correspond to multiple things and even vice-versa.
+                    </li>
+                </ol>
+            </p>
+            <p>
+                In contrast to PropertyAffordances, which are generically mapped to BACnet Properties (mostly the Present Value property),
+                interactions related to events come with a specific payload specified by the BACnet standard. The flexibility that would be for example possible
+                for an HTTP longpoll-based event notification with a custom HTTP body is not possible in the BACnet context.
+                Thus, it is necessary for the WoT consumer to work with a logical data schema that is influenced by the BACnet standard.
+                Still, this binding takes an approach to define the data schemas of the interaction affordances as independent as possible from BACnet, in
+                order to avoid a direct dependency of WoT consumers to a specific protocol.
+            </p>
+            <p>
+                With this background, this binding takes some simplifying design decisions:
+                <ol>
+                    <li>
+                        When the BACnet payload is fixed by the BACnet standard, e.g. for event subscription and alarm acknowledgement,
+                        the binding doesn't model the BACnet data with <code>bacnet:hasDataType</code>.
+                    </li>
+                    <li>
+                        Some features of the BACnet event model are abstracted away: filtering alarms based on day of week, time of day and event state;
+                        and using unconfirmed event notifications. If these become necessary, they can be added in a future version.
+                    </li>
+                    <li>
+                        Payloads containing three event states (Normal, OffNormal, Fault) are split into simpler payloads for each event state. For instance,
+                        GetEventInformation sends one array item for each BACnet object containing three flags, three timestamps, three acknowledge flags etc.
+                        for each possible event state. This binding splits that payload in the ActionAffordance's output into multiple payloads for each
+                        active event with one timestamp, acknowledge flag etc. Ths approach makes the output similar to EventAffordance data payload and removes
+                        the three-event state-based BACnet design from the WoT Consumer's view.
+                    </li>
+                </ol>
+            </p>
+            <p>
+                The resulting data payloads look like this:
+            </p>
+            <table class="def">
+                <thead>
+                    <tr>
+                        <th>Data</th>
+                        <th>WoT Model</th>
+                        <th>BACnet Model (with simplifications)</th>
+                        <th>Remarks</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>EventAffordance.subscription</td>
+                        <td>Not modeled, subscription is implicit</td>
+                        <td>
+                            <ul>
+                                <li>valid-days</li>
+                                <li>from-time</li>
+                                <li>to-time</li>
+                                <li>recipient</li>
+                                <li>process-identifier</li>
+                                <li>issue-confirmed</li>
+                                <li>transitions</li>
+                            </ul>
+                        </td>
+                        <td>
+                            The simplifications below allow to omit the WoT Data Model.
+                            <ul>
+                                <li>valid-days &#8592; all days</li>
+                                <li>from-time &#8592; all time</li>
+                                <li>to-time &#8592; all time</li>
+                                <li>recipient &#8592; BACnet address of the WoT Consumer</li>
+                                <li>process-identifier &#8592; BACnet process ID of the WoT consumer</li>
+                                <li>issue-confirmed-notifications &#8592; always true</li>
+                                <li>transitions &#8592; all transitions</li>
+                            </ul>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>EventAffordance.cancellation</td>
+                        <td>Not modeled, cancellation is implicit</td>
+                        <td>Same as EventAffordance.subscription</td>
+                        <td>
+                            The same simplifications allow to omit the WoT Data Model.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>EventAffordance.data</td>
+                        <td>
+                            <ul>
+                                <li>source: IRI of the BACnet object sending the event</li>
+                                <li>time: Timestamp of the event</li>
+                                <li>prio: Priority of the event</li>
+                                <li>ackReq (opt.): Flag indicating if acknowledge is required. Default is false.</li>
+                                <li>toState: The target state of the event transition</li>
+                                <li>origSource (opt.): In case of algorithmic reporting, the IRI of the object monitored by the event-sending object.</li>
+                                <li>eventType (opt.): If the event is a regular event transition, an acknowledge notification or a general sync-required event. Default is regular.</li>
+                                <li>values (opt.): Additional values associated with the event, e.g. high-limit in case the value exceeded an OffNormal limit.</li>
+                                <li>message (opt.): The message associated with the event.</li>
+                                <li>inactive (opt.): Flag if the event is not active anymore, default is false. This is needed for inactive, but not yet acknowledged events; they are there for symmetry with GetCurrentEvents action.</li>
+                            </ul>
+                        </td>
+                        <td>
+                            <ul>
+                                <li>process-identifier</li>
+                                <li>initiating-device-identifier</li>
+                                <li>event-object-identifier</li>
+                                <li>time-stamp</li>
+                                <li>notification-class</li>
+                                <li>priority</li>
+                                <li>event-type</li>
+                                <li>message-text</li>
+                                <li>notify-type</li>
+                                <li>ack-required</li>
+                                <li>from-state</li>
+                                <li>to-state</li>
+                                <li>event-values</li>
+                            </ul>
+                        </td>
+                        <td>
+                            We focus only on ConfirmedEventNotification, unconfirmed event notifications are currently not supported.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>GetCurrentEvents: ActionAffordance.input</td>
+                        <td>
+                            <ul>
+                                <li>lastReceivedSource (opt.): IRI of the last received object with event</li>
+                            </ul>
+                        </td>
+                        <td>
+                            <ul>
+                                <li>Last Received Object Identifier</li>
+                            </ul>
+                        </td>
+                        <td></td>
+                    </tr>
+                    <tr>
+                        <td>GetCurrentEvents: ActionAffordance.output</td>
+                        <td>
+                            <ul>
+                                <li>
+                                    currentEvents: Array. Each array item is modeled exactly the same as EventAffordance.data:
+                                    <ul>
+                                        <li>source</li>
+                                        <li>time</li>
+                                        <li>prio</li>
+                                        <li>ackReq (opt.)</li>
+                                        <li>toState</li>
+                                        <li>origSource (opt.)</li>
+                                        <li>eventType (opt.)</li>
+                                        <li>values (opt.)</li>
+                                        <li>message (opt.)</li>
+                                        <li>inactive (opt.)</li>
+                                    </ul>
+                                </li>
+                                <li>moreEvents: Flag indicating if more events should be queried</li>
+                            </ul>
+                        </td>
+                        <td>
+                            <ul>
+                                <li>
+                                    List of Event Summaries:
+                                    <ul>
+                                        <li>Object Identifier</li>
+                                        <li>Event State</li>
+                                        <li>Acknowledged Transitions</li>
+                                        <li>Event Timestamps</li>
+                                        <li>Notify Type</li>
+                                        <li>Event Enable</li>
+                                        <li>Event Priorities</li>
+                                    </ul>
+                                </li>
+                                <li>More Events</li>
+                            </ul>
+                        </td>
+                        <td>
+                            As indicated above, the BACnet payload and the ActionAffordance output differ especially around how events are grouped.
+                            In the BACnet payload one list item represents one object with its three possible events, which is reflected in Event State, Acknowledged Transitions, Event Timestamps and Priorities.
+                            This is to be processed and split into one standalone event for every current event of this object, or past unacknowledged event, with corresponding timestamp, priority...
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>AcknowledgeEvent: ActionAffordance.input</td>
+                        <td>
+                            <ul>
+                                <li>eventSource: Source of the event to be acknowledged</li>
+                                <li>eventState: To-state of the event to be acknowledged</li>
+                                <li>eventTime: Timestamp of the event to be acknowledged</li>
+                                <li>eventTime: Timestamp of the event to be acknowledged</li>
+                                <li>ackSource: String describing the acknowledgement source</li>
+                                <li>ackTime: Timestamp of the acknowledge operation</li>
+                            </ul>
+                        </td>
+                        <td>
+                            <ul>
+                                <li>Process Identifier</li>
+                                <li>Object Identifier</li>
+                                <li>Event State</li>
+                                <li>Event Timestamp</li>
+                                <li>Acknowledgement Source</li>
+                                <li>Time of Acknowledgement</li>
+                            </ul>
+                        </td>
+                        <td>
+                            Process Identifier is to be set by WoT Consumer corresponding to what it has entered at subscription time.
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <p>
+                Detailed schemata of these payloads can be found in the JSON Schema linked in this file's header.
+                Examples below shall also be helpful in understanding the details.
+            </p>
+        </section>
         <!--
         <section id="possible-mappings">
             <h3>Possible mappings</h3>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1032,8 +1032,27 @@ lowercase = %x61-7A  ; "a" to "z"
                 <ol>
                     <li>Each Notification Class is mapped to an EventAffordance. This maps directly to the subscription granularity.</li>
                     <li>Event Enrollment objects used for algorithmic reporting are not explicitly mapped; they are not relevant to the WoT consumer, per se.</li>
-                    <li>Special event-related actions (getting current events and acknowledging events) are mapped to ActionAffordances.</li>
-
+                    <li>
+                        Special event-related actions (getting current events and acknowledging events) are mapped to ActionAffordances.
+                        <div class="note">
+                            <p>The WoT consumer does not need to know the details of BACnet alarming, it can simply interact with the InteractionAffordances of the Thing,
+                            as per their data schemata. However the consumer still needs to have an implicit understanding about the relations
+                            between the InteractionAffordances:</p>
+                            <ol>
+                                <li>
+                                    <code>GetCurrentEvents</code> action can be used to fetch all current events of the thing, which would not be received
+                                    just by subscribing to events. This action delivers the same payload as the EventAffordance's data.
+                                </li>
+                                <li>
+                                    <code>AcknowledgeEvent</code> action can be used for all events (including the ones received via <code>GetCurrentEvents</code>),
+                                    where the <code>ackReq</code> field is true. Here the <code>source</code> field of the event should match the <code>eventSource</code>
+                                    field of <code>AcknowledgeEvent.input</code>.
+                                </li>
+                            </ol>
+                            <p>Future work on <a href="https://github.com/w3c/wot-thing-description/blob/main/planning/work-items/new-features.md#manageable-affordances">Manageable Affordances</a>
+                            will improve this by modelling the relations between InteractionAffordances.</p>
+                        </div>
+                    </li>
                     <li>
                         Thing is assumed to be mapped to the BACnet device. While this is simple, it is not a mandatory decision.
                         In specific cases, one BACnet device can correspond to multiple things, and even vice-versa.
@@ -1048,7 +1067,6 @@ lowercase = %x61-7A  ; "a" to "z"
                 Thus, it is necessary for the WoT consumer to work with a given logical data schema that is influenced by the BACnet standard.
                 Still, this binding takes an approach to define the data schemata of the InteractionAffordances as independently as possible from BACnet, in
                 order to avoid a direct dependency of WoT consumers on a specific protocol.
-
             </p>
             <p>
                 With this background, this binding takes some simplifying design decisions:

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1426,6 +1426,305 @@ lowercase = %x61-7A  ; "a" to "z"
 }
 </pre>
 
+        <p>
+            [[[#example-event]]] shows the InteractionAffordances for using BACnet events:
+
+            <ol>
+                <li>One EventAffordance for every Notification Class object</li>
+                <li>One ActionAffordance for the Device Object for GetEventInfo, named as GetCurrentEvents</li>
+                <li>One ActionAffordance for the Device Object for AcknowledgeAlarm, named as AcknowledgeEvent</li>
+            </ol>
+        </p>
+
+        <pre id="example-event" class="example" title="InteractionAffordances for BACnet Event">
+        {
+        "@context": ["https://www.w3.org/2022/wot/td/v1.1",
+        {
+        "bacv": "https://example.org/bacnet"
+        }],
+        ...
+        "actions": {
+            "GetCurrentEvents": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "lastReceivedSource": {
+                      "type": "string",
+                      "format": "iri-reference"
+                    }
+                  }
+                },
+                "output": {
+                  "type": "object",
+                  "properties": {
+                    "currentEvents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "format": "iri-reference"
+                          },
+                          "time": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "prio": {
+                            "type": "integer"
+                          },
+                          "ackReq": {
+                            "type": "integer",
+                            "enum": [
+                              0,
+                              1
+                            ],
+                            "default": 0
+                          },
+                          "toState": {
+                            "type": "string",
+                            "enum": [
+                              "fault",
+                              "offnormal",
+                              "normal"
+                            ]
+                          },
+                          "eventType": {
+                            "type": "string",
+                            "enum": [
+                              "regular",
+                              "ack",
+                              "syncrequired"
+                            ],
+                            "default": "regular"
+                          },
+                          "origSource": {
+                            "type": "string",
+                            "format": "iri-reference"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "values": {
+                            "type": "object"
+                          },
+                          "inactive": {
+                            "type": "integer",
+                            "enum": [
+                              0,
+                              1
+                            ],
+                            "default": 0
+                          }
+                        },
+                        "required": [
+                          "source",
+                          "time",
+                          "prio",
+                          "toState"
+                        ]
+                      }
+                    }
+                  },
+                  "moreEvents": {
+                    "type": "boolean"
+                  },
+                  "required": [
+                    "currentEvents",
+                    "moreEvents"
+                  ]
+                },
+                "forms": [
+                  {
+                    "href": "bacnet://1/8,1",
+                    "op": [
+                      "invokeaction"
+                    ],
+                    "bacnet:usesService": [
+                      "GetEventInfo"
+                    ]
+                  }
+                ]
+            },
+            "AcknowledgeEvent": {
+                "input": {
+                    "type": "object",
+                    "properties": {
+                        "source": {
+                            "type": "string",
+                            "format": "iri-reference"
+                          },
+                          "toState": {
+                            "type": "string",
+                            "enum": [
+                              "fault",
+                              "offnormal",
+                              "normal"
+                            ]
+                          },
+                          "eventTime": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "ackSource": {
+                            "type": "string"
+                          },
+                          "ackTime": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "required": ["source", "ackState", "eventTime", "ackSource", "ackTime"]
+                    }
+                },
+                "forms": [
+                  {
+                    "href": "bacnet://1/8,1",
+                    "op": [
+                      "invokeaction"
+                    ],
+                    "bacnet:usesService": [
+                      "AcknowledgeAlarm"
+                    ]
+                  }
+                ]
+            }
+        },
+        "events": {
+            "NotifCl2": {
+                "title": "Highest priority notification with acknowledge",
+                "data": {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string",
+                        "format": "iri-reference"
+                      },
+                      "time": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "prio": {
+                        "type": "integer"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "ackReq": {
+                        "type": "integer",
+                        "enum": [0, 1],
+                        "default": 0
+                      },
+                      "toState": {
+                        "type": "string",
+                        "enum": [
+                          "fault",
+                          "offnormal",
+                          "normal"
+                        ]
+                      },
+                      "eventType": {
+                        "type": "string",
+                        "enum": ["regular", "ack", "syncrequired"],
+                        "default": "regular"
+                      },
+                      "origSource": {
+                        "type": "string",
+                        "format": "iri-reference"
+                      },
+                      "values": {
+                        "type": "object"
+                      },
+                      "inactive": {
+                        "type": "integer",
+                        "enum": [0, 1],
+                        "default": 0
+                      }
+                    },
+                    "required": [
+                      "source",
+                      "time",
+                      "prio",
+                      "toState"
+                    ]
+                },
+                "forms": [
+                    {
+                        "href": "bacnet://2/15,2/102",
+                        "op": [
+                            "subscribeevent",
+                            "unsubscribeevent"
+                        ]
+                    }
+                ],
+              },
+            }
+        }
+        </pre>
+
+        <p>
+            The resulting example payloads are available below. [[#example-event-data]] shows an incoming event notification.
+            [[#example-acknowledgeevent-input]] shows, what a WoT Consumer would send for acknowledging this event.
+            And [[#example-getcurrentevents-output]] shows the same alarm and another alarm that happened before in the
+            GetCurrentEvents action's output, note that in the second alarm <code>ackReq</code> value turned to 0,
+            because now this event was acknowledged.
+        </p>
+
+        <pre id="example-event-data" class="example" title="Example event data">
+            {
+                "source": "bacnet://5/0,20",
+                "time": "2024-07-30T12:33:00+00:00",
+                "prio": 150,
+                "message": "Equipment overheat",
+                "ackReq": 1,
+                "toState": "offnormal",
+                "values": {
+                    "deadband": 0.5,
+                    "exceedLim": 50,
+                    "exceedValue": 55,
+                    "statusFlags": [1, 0, 0, 0]
+                }
+            }
+        </pre>
+
+        <pre id="example-acknowledgeevent-input" class="example" title="Example AcknowledgeEvent input">
+            {
+                "source": "bacnet://5/0,20",
+                "toState": "offnormal",
+                "eventTime": "2024-07-30T12:33:00+00:00",
+                "ackSource": "Management Station Operator Acknowledge",
+                "ackTime": "2024-07-30T13:15:00+00:00"
+            }
+        </pre>
+
+        <pre id="example-getcurrentevents-output" class="example" title="Example GetCurrentEvents output">
+            {
+                "currentEvents": [
+                    {
+                        "source": "bacnet://5/0,12",
+                        "time": "2024-07-21T20:14:00+00:00",
+                        "prio": 200,
+                        "ackReq": 0,
+                        "toState": "fault"
+                    },
+                    {
+                        "source": "bacnet://5/0,20",
+                        "time": "2024-07-30T12:33:00+00:00",
+                        "prio": 150,
+                        "message": "Equipment overheat",
+                        "ackReq": 0,
+                        "toState": "offnormal",
+                        "values": {
+                            "deadband": 0.5,
+                            "exceedLim": 50,
+                            "exceedValue": 55,
+                            "statusFlags": [0, 0, 0, 0]
+                        }
+                    }
+                ],
+                "moreEvents": false
+            }
+        </pre>
+
     </section>
 </body>
 

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -907,7 +907,7 @@ lowercase = %x61-7A  ; "a" to "z"
                                 {
                                     "type": "string",
                                     "pattern": "^(([0-9A-F]{2}-?)+|(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}={2}))$",
-                                    "$comment": "Binary data encoded in hex, dotted decimal (e.g. IPv4 address) or base64"
+                                    "$comment": "Binary data encoded in hex, dotted decimal (e.g., IPv4 address) or base64"
                                 }
                             </code>
                         </td>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -998,7 +998,7 @@ lowercase = %x61-7A  ; "a" to "z"
         <section id="event-mappings">
             <h3>Mappings related to events</h3>
             <p>
-                BACnet has an extensive event model, see [[BACnet]] Chapter 13. Alarm and Event Services for a complete description.
+                BACnet has an extensive alarm model, see [[BACnet]] Chapter 13. Alarm and Event Services for a complete description.
                 The fundamental aspects are:
                 <ol>
                     <li>
@@ -1010,13 +1010,13 @@ lowercase = %x61-7A  ; "a" to "z"
                         or dedicated other objects can monitor other objects (algorithmic reporting)
                     </li>
                     <li>
-                        Alarms are always sent via Notification Class objects, which keep lists of alarm recipients, i.e. event subscriptions
-                        are always done to the Notification Classes, it is not possible to receive events only from some of the objects linked
+                        Alarms are always sent via Notification Class objects, which keep lists of alarm recipients, i.e. alarm subscriptions
+                        are always done to the Notification Classes, it is not possible to receive alarms only from some of the objects linked
                         to the same Notification Class. In the typical case, a client will register to all Notification Classes of a BACnet Device.
                     </li>
                     <li>
                         Some alarms can be configured as acknowledgement required. Acknowledgement is defined by BACnet as a manual action
-                        performed by a human operator, and is separate from the confirmation of the successful reception of the event notification. 
+                        performed by a human operator, and is separate from the confirmation of the successful reception of the event notification.
                     </li>
                 </ol>
                 The picture below demonstrates these key aspects and how they are mapped to the WoT concepts.
@@ -1050,7 +1050,7 @@ lowercase = %x61-7A  ; "a" to "z"
                         data and alarm acknowledgement, the binding doesn't model the BACnet data with <code>bacnet:hasDataType</code>.
                     </li>
                     <li>
-                        Some features of the BACnet event model are abstracted away: filtering alarms based on day of week, time of day and event state;
+                        Some features of the BACnet alarm model are abstracted away: filtering alarms based on day of week, time of day and event state;
                         and using unconfirmed event notifications. If these become necessary, they can be added in a future version.
                     </li>
                     <li>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1057,8 +1057,9 @@ lowercase = %x61-7A  ; "a" to "z"
                         data or alarm acknowledgement — the binding doesn't model the BACnet data with <code>bacnet:hasDataType</code>.
                     </li>
                     <li>
-                        Some features of the BACnet alarm model are abstracted away: filtering alarms based on day of week, time of day and event state;
+                        Some features of the BACnet alarm model are abstracted away: filtering alarms based on day of week, time of day, and event state;
                         and using unconfirmed event notifications. If these become necessary, they can be added in a future version.
+
                     </li>
                     <li>
                         Payloads containing three event states (Normal, OffNormal, Fault) are split into simpler payloads for each event state. For instance,

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1012,7 +1012,7 @@ lowercase = %x61-7A  ; "a" to "z"
                     <li>
                         Alarms are always sent via Notification Class objects, which keep lists of alarm recipients, i.e. event subscriptions
                         are always done to the Notification Classes, it is not possible to receive events only from some of the objects linked
-                        to the same Notification Class.
+                        to the same Notification Class. In the typical case, a client will register to all Notification Classes of a BACnet Device.
                     </li>
                 </ol>
                 The picture below demonstrates these key aspects and how they are mapped to the WoT concepts.
@@ -1031,19 +1031,19 @@ lowercase = %x61-7A  ; "a" to "z"
                 </ol>
             </p>
             <p>
-                In contrast to PropertyAffordances, which are generically mapped to BACnet Properties (mostly the Present Value property),
+                In contrast to PropertyAffordances, which are generically mapped to BACnet,
                 interactions related to events come with a specific payload specified by the BACnet standard. The flexibility that would be for example possible
-                for an HTTP longpoll-based event notification with a custom HTTP body is not possible in the BACnet context.
-                Thus, it is necessary for the WoT consumer to work with a logical data schema that is influenced by the BACnet standard.
-                Still, this binding takes an approach to define the data schemas of the interaction affordances as independent as possible from BACnet, in
+                for an HTTP longpoll-based event notification with a custom HTTP body is not possible in BACnet context.
+                Thus, it is necessary for the WoT consumer to work with a given logical data schema that is influenced by the BACnet standard.
+                Still, this binding takes an approach to define the data schemata of the InteractionAffordances as independent as possible from BACnet, in
                 order to avoid a direct dependency of WoT consumers to a specific protocol.
             </p>
             <p>
                 With this background, this binding takes some simplifying design decisions:
                 <ol>
                     <li>
-                        When the BACnet payload is fixed by the BACnet standard, e.g. for event subscription and alarm acknowledgement,
-                        the binding doesn't model the BACnet data with <code>bacnet:hasDataType</code>.
+                        When the BACnet payload is fixed by the BACnet standard for a given service, e.g. for event subscription,
+                        data and alarm acknowledgement, the binding doesn't model the BACnet data with <code>bacnet:hasDataType</code>.
                     </li>
                     <li>
                         Some features of the BACnet event model are abstracted away: filtering alarms based on day of week, time of day and event state;
@@ -1053,8 +1053,8 @@ lowercase = %x61-7A  ; "a" to "z"
                         Payloads containing three event states (Normal, OffNormal, Fault) are split into simpler payloads for each event state. For instance,
                         GetEventInformation sends one array item for each BACnet object containing three flags, three timestamps, three acknowledge flags etc.
                         for each possible event state. This binding splits that payload in the ActionAffordance's output into multiple payloads for each
-                        active event with one timestamp, acknowledge flag etc. Ths approach makes the output similar to EventAffordance data payload and removes
-                        the three-event state-based BACnet design from the WoT Consumer's view.
+                        active event with one timestamp, acknowledge flag etc. This approach makes the output similar to EventAffordance data
+                        payload and removes the three-event state-based BACnet design from the WoT Consumer's view.
                     </li>
                 </ol>
             </p>
@@ -1066,7 +1066,7 @@ lowercase = %x61-7A  ; "a" to "z"
                     <tr>
                         <th>Data</th>
                         <th>WoT Model</th>
-                        <th>BACnet Model (with simplifications)</th>
+                        <th>BACnet Model</th>
                         <th>Remarks</th>
                     </tr>
                 </thead>
@@ -1102,9 +1102,7 @@ lowercase = %x61-7A  ; "a" to "z"
                         <td>EventAffordance.cancellation</td>
                         <td>Not modeled, cancellation is implicit</td>
                         <td>Same as EventAffordance.subscription</td>
-                        <td>
-                            The same simplifications allow to omit the WoT Data Model.
-                        </td>
+                        <td>Same as EventAffordance.subscription</td>
                     </tr>
                     <tr>
                         <td>EventAffordance.data</td>
@@ -1198,7 +1196,7 @@ lowercase = %x61-7A  ; "a" to "z"
                         </td>
                         <td>
                             As indicated above, the BACnet payload and the ActionAffordance output differ especially around how events are grouped.
-                            In the BACnet payload one list item represents one object with its three possible events, which is reflected in Event State, Acknowledged Transitions, Event Timestamps and Priorities.
+                            In the BACnet payload, one list item represents one object with its three possible events, which is reflected in Event State, Acknowledged Transitions, Event Timestamps and Priorities.
                             This is to be processed and split into one standalone event for every current event of this object, or past unacknowledged event, with corresponding timestamp, priority...
                         </td>
                     </tr>
@@ -1430,9 +1428,9 @@ lowercase = %x61-7A  ; "a" to "z"
             [[[#example-event]]] shows the InteractionAffordances for using BACnet events:
 
             <ol>
-                <li>One EventAffordance for every Notification Class object</li>
                 <li>One ActionAffordance for the Device Object for GetEventInfo, named as GetCurrentEvents</li>
                 <li>One ActionAffordance for the Device Object for AcknowledgeAlarm, named as AcknowledgeEvent</li>
+                <li>One EventAffordance for every Notification Class object</li>
             </ol>
         </p>
 
@@ -1662,9 +1660,9 @@ lowercase = %x61-7A  ; "a" to "z"
         </pre>
 
         <p>
-            The resulting example payloads are available below. [[#example-event-data]] shows an incoming event notification.
-            [[#example-acknowledgeevent-input]] shows, what a WoT Consumer would send for acknowledging this event.
-            And [[#example-getcurrentevents-output]] shows the same alarm and another alarm that happened before in the
+            The resulting example payloads are available below. [[[#example-event-data]]] shows an event notification.
+            [[[#example-acknowledgeevent-input]]] shows what a WoT Consumer would send for acknowledging this event.
+            And [[[#example-getcurrentevents-output]]] shows the same alarm and another alarm that happened before in the
             GetCurrentEvents action's output, note that in the second alarm <code>ackReq</code> value turned to 0,
             because now this event was acknowledged.
         </p>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -998,12 +998,14 @@ lowercase = %x61-7A  ; "a" to "z"
         <section id="event-mappings">
             <h3>Mappings related to events</h3>
             <p>
-                BACnet has an extensive alarm model, see [[BACnet]] Chapter 13. Alarm and Event Services for a complete description.
+                BACnet has an extensive alarm model; see [[BACnet]] Chapter 13. Alarm and Event Services for a complete description.
+
                 The fundamental aspects are:
                 <ol>
                     <li>
-                        There are three event states: Normal (no event), OffNormal (e.g. operating temperature outside of the normal range)
-                        and Fault (e.g. defect sensor). Events are sent in case of transitions, including self-transitions and toNormal transitions.
+                        There are three event states: Normal (no event); OffNormal (e.g., operating temperature outside of the normal range);
+                        and Fault (e.g., defective sensor). Events are sent for transitions, including self-transitions and toNormal transitions.
+
                     </li>
                     <li>
                         Objects can monitor themselves for event states (intrinsic reporting),
@@ -1030,7 +1032,8 @@ lowercase = %x61-7A  ; "a" to "z"
                     <li>Special event-related actions are mapped to ActionAffordances: getting current events and acknowledging events.</li>
                     <li>
                         Thing is assumed to be mapped to the BACnet device. While this is simple, it is not a mandatory decision.
-                        In specific cases one BACnet device can correspond to multiple things and even vice-versa.
+                        In specific cases, one BACnet device can correspond to multiple things, and even vice-versa.
+
                     </li>
                 </ol>
             </p>
@@ -1046,8 +1049,8 @@ lowercase = %x61-7A  ; "a" to "z"
                 With this background, this binding takes some simplifying design decisions:
                 <ol>
                     <li>
-                        When the BACnet payload is fixed by the BACnet standard for a given service, e.g. for event subscription,
-                        data and alarm acknowledgement, the binding doesn't model the BACnet data with <code>bacnet:hasDataType</code>.
+                        When the BACnet payload is fixed by the BACnet standard for a given service — e.g., event subscription, or
+                        data or alarm acknowledgement — the binding doesn't model the BACnet data with <code>bacnet:hasDataType</code>.
                     </li>
                     <li>
                         Some features of the BACnet alarm model are abstracted away: filtering alarms based on day of week, time of day and event state;
@@ -1055,9 +1058,9 @@ lowercase = %x61-7A  ; "a" to "z"
                     </li>
                     <li>
                         Payloads containing three event states (Normal, OffNormal, Fault) are split into simpler payloads for each event state. For instance,
-                        GetEventInformation sends one array item for each BACnet object containing three flags, three timestamps, three acknowledge flags etc.
+                        GetEventInformation sends one array item for each BACnet object containing three flags, three timestamps, three acknowledge flags, etc.,
                         for each possible event state. This binding splits that payload in the ActionAffordance's output into multiple payloads for each
-                        active event with one timestamp, acknowledge flag etc. This approach makes the output similar to EventAffordance data
+                        active event, with one timestamp, acknowledge flag, etc. This approach makes the output similar to the EventAffordance data
                         payload and removes the three-event state-based BACnet design from the WoT Consumer's view.
                     </li>
                 </ol>
@@ -1077,7 +1080,8 @@ lowercase = %x61-7A  ; "a" to "z"
                 <tbody>
                     <tr>
                         <td>EventAffordance.subscription</td>
-                        <td>Not modeled, subscription is implicit</td>
+                        <td>Not modeled; subscription is implicit</td>
+
                         <td>
                             <ul>
                                 <li>valid-days</li>
@@ -1142,7 +1146,8 @@ lowercase = %x61-7A  ; "a" to "z"
                             </ul>
                         </td>
                         <td>
-                            We focus only on ConfirmedEventNotification, unconfirmed event notifications are currently not supported.
+                            We focus only on ConfirmedEventNotification; unconfirmed event notifications are currently not supported.
+
                         </td>
                     </tr>
                     <tr>
@@ -1234,7 +1239,8 @@ lowercase = %x61-7A  ; "a" to "z"
             </table>
             <p>
                 Detailed schemata of these payloads can be found in the JSON Schema linked in this file's header.
-                Examples below shall also be helpful in understanding the details.
+                Examples below will be helpful in understanding the details.
+
             </p>
         </section>
         <!--
@@ -1685,9 +1691,9 @@ lowercase = %x61-7A  ; "a" to "z"
         </pre>
 
         <p>
-            [[[#example-event-data]]] shows an event notification because of an overheating equipment. Event <code>message</code>
-            gives this as a useful hint, <code>prio</code> is set accordingly. <code>values</code> object gives additional details
-            about the event that the current value is 55 and the exceeded limit was 50. The unit of these values can be found at the
+            [[[#example-event-data]]] shows an event notification because of an overheating piece of equipment. Event <code>message</code>
+            gives this as a useful hint; <code>prio</code> is set accordingly. <code>values</code> object gives additional details
+            about the event — that the current value is 55, and the exceeded limit was 50. The unit of these values can be found at the
             <code>source</code> object that triggered this event.
             Because overheating events are important for the operator to notice, <code>ackReq</code> is set, so the operator definitely
             will see the event, even after the overheating condition is over.
@@ -1741,7 +1747,7 @@ lowercase = %x61-7A  ; "a" to "z"
             If the event client wants to get a list of all events of the device, it will invoke the GetCurrentEvents action, and will receive
             te payload shown in [[[#example-getcurrentevents-output]]]. Here the event notification about the overheating and a past fault event can be
             seen. This is useful for synchronizing the events known on the client to the events that are on the device, in case of temporary
-            disconnection, reboot of client or device etc. Please note that in the second alarm <code>ackReq</code> value turned to 0,
+            disconnection, reboot of client or device, etc. Please note that in the second alarm, the <code>ackReq</code> value turned to 0,
             because this event was acknowledged by the operator in the meantime.
         </p>
 

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1014,6 +1014,10 @@ lowercase = %x61-7A  ; "a" to "z"
                         are always done to the Notification Classes, it is not possible to receive events only from some of the objects linked
                         to the same Notification Class. In the typical case, a client will register to all Notification Classes of a BACnet Device.
                     </li>
+                    <li>
+                        Some alarms can be configured as acknowledgement required. Acknowledgement is defined by BACnet as a manual action
+                        performed by a human operator, and is separate from the confirmation of the successful reception of the event notification. 
+                    </li>
                 </ol>
                 The picture below demonstrates these key aspects and how they are mapped to the WoT concepts.
             </p>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1679,7 +1679,7 @@ lowercase = %x61-7A  ; "a" to "z"
                     "deadband": 0.5,
                     "exceedLim": 50,
                     "exceedValue": 55,
-                    "statusFlags": [1, 0, 0, 0]
+                    "statusFlags": [0, 0, 0, 0]
                 }
             }
         </pre>

--- a/images/bacnet_events.drawio.svg
+++ b/images/bacnet_events.drawio.svg
@@ -1,0 +1,661 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1028px" height="832px" viewBox="-0.5 -0.5 1028 832" content="&lt;mxfile&gt;&lt;diagram id=&quot;x8Etut7WmsOYzxT8R3wY&quot; name=&quot;Page-1&quot;&gt;7VxJb9s4FP41ATqHBtolH52tc0jbAAkw0yMjUTZbWTQkOon764eUqY2UbFmr3XEPjUlR23vf2x91pd+uPr5EYL38ij0YXGmK93Gl311pmmrYCv3DZrZ8RnP4zCJCHp/LJ57Rb8gn02Ub5MG4tJBgHBC0Lk+6OAyhS0pzIIrwe3mZj4PyXddgAaWJZxcE8uw/yCPL3axjKvn83xAtlumdVYUfWYF0MZ+Il8DD74Up/f5Kv40wJrtfq49bGDDqpXTZnfdQczR7sAiGpMkJGn8Msk3fDXr0VfkQR2SJFzgEwX0+exPhTehBdgGFjvI1jxiv6aRKJ39CQracb2BDMJ1aklXAj9Jni7b/8vOTwQ82uDbT4d1H8eDdNht5c8Y9OgxxCHczDygI+PHdu7AXqKUGn4rxJnL5KosDCEQLyFc5GScohiFeQfoUdEkEA0DQW/nqgGNpka3LyU1/cIpXU1+/UL+C+qoyEvmNC/mryK+NRH5zWvLnFP9RIng78sMPRAqXpaMf6R3p7/yibLDtnWVGR5Ylp9L3A9vCgjVGIYkLV35iE3QBN+SWzo1YasZtwdYI62eOsW89/bF7ghw82as0whMnzBsINvyN7+AbomQTYZaDiPHnfYkIfF6DhL7v1GMpA4ZfFEYEfuxnk0x/foJplwll8eF77juoqUOwLPgN6bouQmZLRIFv7LEnED0PxMuM6u2w7wyA/aaUdCRK3sxvQ8gA/v31J3MzKUev2QlUcaAwRm7yFGtKKRQuJgehZQrSOmuIQrMHFKaOewXxLLBiLxu+xuzP/Q6cyn0Y4SBYJYPyiiK5P4FggSNElqsysf86OWrr+pjUViVqx5s1jN5QLCvDMWwut41qwTLmdrLaNmZ2OjPazdykHpRMCtZenaIakzgTYKII7N89Az9LQMBx1lHVDuuvExMaQxlTaHSJPt8wQT5yKYNxSI/cBiCOJyfSTCt7UY29iV6IZJwnkcY1dhMHNmWFqXUNLKeNbPRB9K5lCM6QLvB991iS3q1Q4II0NlTgQ8dajtNtvWbrAuS7xWaqHJydRhzSNh3To2sxDMRtkaNpvuVoiOvG/gv16KPI0epZx1jj2mbnlMzOeVsd+7StjmUdkO0eRXJ2ooq7pQK2Lwp4D7dT3SQrYH0ucZzqSVJmUEwi/Ave4gBHuVz7VKiFKRCgRUiHAfTZFZjOpRFEMOfTK+R5CWKqNHYZRT4OSYo6NR3v8ENdDv0mAK8weMIxSsIT/c6l4IBR4Z6PwoLs3j2YAzHvq8rWwKowBqJWaGMMNDkF9A9+uXCxDRenY6L2J1n0dgq7yjxrXc1zYwZcCvTVDBirQeJSoq9hwGwsBlyK9L0xTdf68DOPzRyp6nGZIMMatkpfUaZ/WZ5C8C7Y+TGL9BVV+qcIr+nbbOe+jyMPhCfQxqCKOcgxk+oV5fdPIWa4XbH+UkoGlhSi/73cdaz+VkSZvZJt1FKwJofvZ4CsUQt/uhzzJl0IJ0QfQ5mw5qfLoeQKh4jgKE6hNIWP0EMySNdkIz1abJHe/IxgN6rC108q9jqjKmql69m1pbrGt9QEj6BtQtuwxymjHusM61a39X2XUdNM8HmZ83HN1Ul1X5y52uilr3w4taEKBbUBKyO6HLaeghc0YZtkyrQRAGOoBypgTQGjjVc41eWY/pwBkymigho61MM7EMg6Jz8bgmzWF8jEC/UIMjkr8gWS203EiJqEE3FS81PmLquMnbCPkG0KHsVHkLMic/dXiN8Dhs/dHoTzIJtpjEi29F4X16oH16prCW1k18rQB1NihnqBVW+wGsY2DgYrUxkOVrID9g0/gE0g967F72gVgF2fi9CKkja5SC0nUpuLu0SB9wi2eMN4ERPg/kpHN0scod/0yiDvsQFR2uKiK6UVz+xMDowIxnTNU4qDfOoRxIRfymVnoZA9XNZMk3bqXLEdRexfsi4IwDpGr8m7KSUZSt40cosPVO4CohfyfX6hYitQMu/7bnIGp+JDzXGPur0vKVZz2HfruBXxVJVqcCrsYfbJkU472OXU+DccrSiXO/kJOSeMfQyt5UM950rg7oH64sbmqtKWWkH9PoqmpiYRn+Dvvl/DgQJ9RRF+xYTgVVm30wgt3M1wVjh7KZtrfa252i+0OWhH9Tkk/XA3VE0sElwJfXk11qRoOsx6C1O0JmZNZyxnPzNxRfZ/TrtrO1obU3ByZ6K1qTES0oU+C7fGvh/DrnbFlDcK1qPu/yH39qhyL2fiCJ5Y6O2i0Ct7hX6/7BZUgl1SCeoBldDOhUyxXBL6/bz/rFwbpqMLgq/0Ivi2IPi22lLwbcUWdJMtVpQOeqz9Kg3ZGZ0atKVEnrY/k9cQtEfmFFtituIjIBNi1hG28JuzlpidCeC37AzDE2FWTi5Wh09/ppET95BbzphGTs5QkprgdRx1Uf52h92Lujgy89JOXRgVO77MmuRbUV3Y1jAmbiZKeWt1YVwrhX+aYO4mVR2WHBhPGJvV4M0+BLgDMD6Yo3Q30Vu+0byN3e3Rq5smlKtwxIyWgDeF/ZS2WNJomoM8HBUe/XUGIQtlW/32zFtVqY6TkqWD/XHDyBLVgLOSPFkU53tTLnTwBCNEiZ8lTFsKWVW+pMaj6LpvXES+0yxpfvhCZjMr0VUerL7lQU7BTOQd1UQ+04jDUT5aS9RXBV/DlDLPDvWqIjR+2Ly7qLYYJp5gzUondJcTuV00+55K+qXFZwIIpH+/AneJGPqG2CJ+uHrWfZP4VfeQz1LLvopZsdk7a0nquNubDvPPvO94m38tX7//Dw==&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 580 110 L 580 205 L 600 205" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 580 110 L 580 345 L 600 345" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 580 110 L 580 415 L 600 415" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 580 110 L 580 160 L 934 160 L 934 180" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="520" y="50" width="120" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 80px; margin-left: 521px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Device
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="580" y="84" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Device
+                </text>
+            </switch>
+        </g>
+        <path d="M 720 205 L 867.63 205" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+        <path d="M 872.88 205 L 865.88 208.5 L 867.63 205 L 865.88 201.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 205px; margin-left: 797px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                event
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="797" y="208" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    event
+                </text>
+            </switch>
+        </g>
+        <rect x="600" y="180" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 205px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                BACnet Object w. intrinsic reporting
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="660" y="209" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    BACnet Object w. int...
+                </text>
+            </switch>
+        </g>
+        <rect x="600" y="320" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 345px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                BACnet Event Enrollment  Object (algorithmic reporting)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="660" y="349" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    BACnet Event Enrollm...
+                </text>
+            </switch>
+        </g>
+        <path d="M 720 345 L 740 345 L 740 415 L 726.37 415" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+        <path d="M 721.12 415 L 728.12 411.5 L 726.37 415 L 728.12 418.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 381px; margin-left: 740px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                supervise
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="740" y="384" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    supervise
+                </text>
+            </switch>
+        </g>
+        <rect x="600" y="390" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 415px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                BACnet Object
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="660" y="419" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    BACnet Object
+                </text>
+            </switch>
+        </g>
+        <rect x="874" y="250" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 275px; margin-left: 875px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Notification Class
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="934" y="279" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Notification Class
+                </text>
+            </switch>
+        </g>
+        <rect x="874" y="180" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 205px; margin-left: 875px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Notification Class
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="934" y="209" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Notification Class
+                </text>
+            </switch>
+        </g>
+        <path d="M 580 110 L 580 160 L 830 160 L 830 262.57 L 874 262.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 720 345 L 797 345 L 797 275 L 867.63 275" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+        <path d="M 872.88 275 L 865.88 278.5 L 867.63 275 L 865.88 271.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 311px; margin-left: 797px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                event
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="797" y="314" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    event
+                </text>
+            </switch>
+        </g>
+        <rect x="600" y="250" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 275px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                BACnet Object w. intrinsic reporting
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="660" y="279" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    BACnet Object w. int...
+                </text>
+            </switch>
+        </g>
+        <path d="M 580 110 L 580 275 L 600 275" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 720 275 L 867.63 275" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+        <path d="M 872.88 275 L 865.88 278.5 L 867.63 275 L 865.88 271.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 275px; margin-left: 797px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                event
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="797" y="278" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    event
+                </text>
+            </switch>
+        </g>
+        <rect x="520" y="0" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 58px; height: 1px; padding-top: 15px; margin-left: 522px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                                BACnet:
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="522" y="20" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" font-weight="bold">
+                    BACnet:
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="0" width="60" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 58px; height: 1px; padding-top: 15px; margin-left: 2px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                                WoT:
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2" y="20" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" font-weight="bold">
+                    WoT:
+                </text>
+            </switch>
+        </g>
+        <path d="M 60 110 L 60 205 L 80 205" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 60 110 L 60 345 L 80 345" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 60 110 L 60 415 L 80 415" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 60 110 L 60 160 L 414 160 L 414 180" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="0" y="50" width="120" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 80px; margin-left: 1px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Thing
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="84" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Thing
+                </text>
+            </switch>
+        </g>
+        <rect x="80" y="180" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 205px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                PropertyAffordance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="140" y="209" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    PropertyAffordance
+                </text>
+            </switch>
+        </g>
+        <rect x="80" y="320" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-dasharray="3 3" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 345px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                (not modeled in TD)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="140" y="349" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    (not modeled in TD)
+                </text>
+            </switch>
+        </g>
+        <rect x="80" y="390" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 415px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                PropertyAffordance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="140" y="419" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    PropertyAffordance
+                </text>
+            </switch>
+        </g>
+        <rect x="354" y="250" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 275px; margin-left: 355px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                EventAffordance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="414" y="279" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    EventAffordance
+                </text>
+            </switch>
+        </g>
+        <path d="M 354 205 L 206.37 205" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+        <path d="M 201.12 205 L 208.12 201.5 L 206.37 205 L 208.12 208.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 205px; margin-left: 277px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                monitorsProperty
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="277" y="208" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    monitorsProperty
+                </text>
+            </switch>
+        </g>
+        <rect x="354" y="180" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 205px; margin-left: 355px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                EventAffordance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="414" y="209" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    EventAffordance
+                </text>
+            </switch>
+        </g>
+        <path d="M 60 110 L 60 160 L 310 160 L 310 262.57 L 354 262.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="80" y="250" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 275px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                PropertyAffordance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="140" y="279" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    PropertyAffordance
+                </text>
+            </switch>
+        </g>
+        <path d="M 60 110 L 60 275 L 80 275" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 354 275 L 206.37 275" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+        <path d="M 201.12 275 L 208.12 271.5 L 206.37 275 L 208.12 278.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 275px; margin-left: 277px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                monitorsProperty
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="277" y="278" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    monitorsProperty
+                </text>
+            </switch>
+        </g>
+        <path d="M 354 275 L 277 275 L 277 415 L 206.37 415" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+        <path d="M 201.12 415 L 208.12 411.5 L 206.37 415 L 208.12 418.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 345px; margin-left: 277px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                monitorsProperty
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="277" y="348" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    monitorsProperty
+                </text>
+            </switch>
+        </g>
+        <rect x="80" y="460" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 485px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                GetCurrentEvents: ActionAffordance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="140" y="489" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    GetCurrentEvents: Ac...
+                </text>
+            </switch>
+        </g>
+        <rect x="80" y="530" width="120" height="50" rx="7.5" ry="7.5" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 555px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                AcknowledgeEvent: ActionAffordance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="140" y="559" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    AcknowledgeEvent: Ac...
+                </text>
+            </switch>
+        </g>
+        <path d="M 60 110 L 60 485 L 80 485" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 60 110 L 60 555 L 80 555" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 770 580 L 770 577 Q 770 550 743 550 L 617 550 Q 590 550 590 577 L 590 580" fill="#ffffc0" stroke="#ff0000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 590 580 L 590 803 Q 590 830 617 830 L 743 830 Q 770 830 770 803 L 770 580" fill="#ffffc0" stroke="#ff0000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 590 580 L 770 580" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" font-weight="bold" text-anchor="middle" font-size="12px">
+            <text x="679.5" y="569.5">
+                NoFault
+            </text>
+        </g>
+        <rect x="620" y="620" width="110" height="60" rx="24" ry="24" fill="#ffffc0" stroke="#ff0000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 650px; margin-left: 621px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                                Normal
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="675" y="654" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    Normal
+                </text>
+            </switch>
+        </g>
+        <path d="M 647.5 680 L 647.5 717.76" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 643 709.88 L 647.5 718.88 L 652 709.88" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 707px; margin-left: 630px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                toOffNormal
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="630" y="707" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    toOffNormal
+                </text>
+            </switch>
+        </g>
+        <rect x="620" y="720" width="110" height="60" rx="24" ry="24" fill="#ffffc0" stroke="#ff0000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 750px; margin-left: 621px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                                OffNormal
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="675" y="754" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    OffNormal
+                </text>
+            </switch>
+        </g>
+        <path d="M 702.5 720 L 702.5 682.24" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 707 690.12 L 702.5 681.12 L 698 690.12" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 706px; margin-left: 713px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                toNormal
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="713" y="706" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    toNormal
+                </text>
+            </switch>
+        </g>
+        <path d="M 874 685 L 732.17 650.53" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 740.89 648.02 L 731.09 650.26 L 738.77 656.76" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 663px; margin-left: 837px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                toNormal
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="837" y="663" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    toNormal
+                </text>
+            </switch>
+        </g>
+        <rect x="874" y="670" width="110" height="60" rx="24" ry="24" fill="#ffffc0" stroke="#ff0000" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 700px; margin-left: 875px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                                Fault
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="929" y="704" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    Fault
+                </text>
+            </switch>
+        </g>
+        <path d="M 770 760 L 872.06 701.12" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 867.48 708.95 L 873.03 700.56 L 862.99 701.16" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 749px; margin-left: 803px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                toFault
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="803" y="749" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    toFault
+                </text>
+            </switch>
+        </g>
+        <path d="M 620 735 Q 590 750 618 764" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 608.94 764.5 L 619 764.5 L 612.96 756.45" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 770px; margin-left: 596px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                toOffNormal
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="596" y="770" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    toOffNormal
+                </text>
+            </switch>
+        </g>
+        <path d="M 620.99 659.18 Q 590 650 618 636" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 612.96 643.55 L 619 635.5 L 608.94 635.5" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 647px; margin-left: 590px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                toNormal
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="590" y="647" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    toNormal
+                </text>
+            </switch>
+        </g>
+        <path d="M 984 715 Q 1010 715 1010 700 Q 1010 685 986.24 685" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 994.12 680.5 L 985.12 685 L 994.12 689.5" fill="none" stroke="#ff0000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 697px; margin-left: 1010px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                toFault
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1010" y="697" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    toFault
+                </text>
+            </switch>
+        </g>
+        <rect x="565" y="500" width="230" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 228px; height: 1px; padding-top: 515px; margin-left: 566px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; overflow-wrap: normal;">
+                                BACnet Event State Machine:
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="680" y="520" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" text-anchor="middle" font-weight="bold">
+                    BACnet Event State Machine:
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>


### PR DESCRIPTION
Bring support for BACnet Events (used interchangeably with Alarms) to WoT BACnet Protocol Binding.

My general approach in this PR is to allow WoT Consumers to interact with EventAffordances in a certain way. I didn't try to cover all features and options of BACnet. I find it better to start simple and add features as they become necessary.

This PR bases on #377, so that one should be merged first.

Preview of rendered doc: <https://deploy-preview-379--wot-binding-templates.netlify.app/bindings/protocols/bacnet/index.html#event-mappings>