### PR TITLE
fix: add day of week to BACnet protocol binding's Date and DateTime types

### DIFF
--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -656,9 +656,10 @@ lowercase = %x61-7A  ; "a" to "z"
                                 {
                                     "type": "string",
                                     "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|\\*)-((3[01]|0[1-9]|[12][0-9])|\\*)(\\s*\\([1-7\\*]\\))?T((2[0-3]|[01][0-9])|\\*):([0-5][0-9]|\\*):([0-5][0-9]|\\*)(\\.[0-9]+)?(Z|[+-]\\d\\d:\\d\\d)?$",
-                                    "$comment": "ISO8601 Date Time Format, extended with day of week (1: Mon, 7: Sun) and with optional wildcards"
+                                    "$comment": "ISO8601 Date Time Format, optionally extended with day of week (1: Mon, 7: Sun) and with optional wildcards"
                                 }
                             </code>
+                            Please see <code>bacv:Date</code> and <code>bacv:Time</code> about the use of wildcards.
                         </td>
                         <td>
                             <code>
@@ -746,9 +747,15 @@ lowercase = %x61-7A  ; "a" to "z"
                                 {
                                     "type": "string",
                                     "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|\\*)-((3[01]|0[1-9]|[12][0-9])|\\*)(\\s*\\([1-7\\*]\\))?$",
-                                    "$comment": "ISO8601 Date Format, extended with day of week (1: Mon, 7: Sun) and with optional wildcards"
+                                    "$comment": "ISO8601 Date Format, optionally extended with day of week (1: Mon, 7: Sun) and with optional wildcards"
                                 }
                             </code>
+
+                            The wildcards are used to indicate simple recurrences, e.g.
+                            <code>*-*-1</code> would indicate the first day of each month, and <code>*-6-* (1)</code> would indicate all Mondays in June.
+                            It is possible to indicate an empty set by giving an invalid day of week such as <code>2024-11-07 (1)</code>
+                            (actually it is a Thursday), the more straightforward way would be to just leave out this entry where this data would occur.
+                            All values may be set to wildcards <code>*-*-* (*)</code> to indicate any date.
                         </td>
                         <td>
                             <code>
@@ -770,6 +777,10 @@ lowercase = %x61-7A  ; "a" to "z"
                                     "$comment": "ISO8601 Time Format with optional wildcards"
                                 }
                             </code>
+
+                            The wildcards are used to indicate occurrences,
+                            e.g. <code>*:00:00Z</code> to indicate all seconds of the first minute of the hour in UTC.
+                            <code>*:*:*</code> can be used to indicate any time.
                         </td>
                         <td>
                             <code>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -655,11 +655,12 @@ lowercase = %x61-7A  ; "a" to "z"
                             <code>
                                 {
                                     "type": "string",
-                                    "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|\\*)-((3[01]|0[1-9]|[12][0-9])|\\*)(\\s*\\([1-7\\*]\\))?T((2[0-3]|[01][0-9])|\\*):([0-5][0-9]|\\*):([0-5][0-9]|\\*)(\\.[0-9]+)?(Z|[+-]\\d\\d:\\d\\d)?$",
+                                    "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|O|E\\*)-((3[01]|0[1-9]|[12][0-9])|O|E\\*)(\\s*\\([1-7\\*]\\))?T((2[0-3]|[01][0-9])|\\*):([0-5][0-9]|\\*):([0-5][0-9]|\\*)(\\.[0-9]+)?(Z|[+-]\\d\\d:\\d\\d)?$",
                                     "$comment": "ISO8601 Date Time Format, optionally extended with day of week (1: Mon, 7: Sun) and with optional wildcards"
                                 }
                             </code>
-                            Please see <code>bacv:Date</code> and <code>bacv:Time</code> about the use of wildcards.
+                            <br />
+                            Please see <code>bacv:Date</code> and <code>bacv:Time</code> about the details of wildcards.
                         </td>
                         <td>
                             <code>
@@ -746,16 +747,30 @@ lowercase = %x61-7A  ; "a" to "z"
                             <code>
                                 {
                                     "type": "string",
-                                    "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|\\*)-((3[01]|0[1-9]|[12][0-9])|\\*)(\\s*\\([1-7\\*]\\))?$",
-                                    "$comment": "ISO8601 Date Format, optionally extended with day of week (1: Mon, 7: Sun) and with optional wildcards"
+                                    "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|O|E\\*)-((3[01]|0[1-9]|[12][0-9])|O|E\\*)(\\s*\\([1-7\\*]\\))?$",
+                                    "$comment": "ISO8601 Date Format, optionally extended with day of week (1: Mon, 7: Sun) and wildcards (O, E, *)"
                                 }
                             </code>
 
-                            The wildcards are used to indicate simple recurrences, e.g.
-                            <code>*-*-1</code> would indicate the first day of each month, and <code>*-6-* (1)</code> would indicate all Mondays in June.
-                            It is possible to indicate an empty set by giving an invalid day of week such as <code>2024-11-07 (1)</code>
-                            (actually it is a Thursday), the more straightforward way would be to just leave out this entry where this data would occur.
-                            All values may be set to wildcards <code>*-*-* (*)</code> to indicate any date.
+                            <ul>
+                                <li><code>O</code> and <code>E</code> can be used in the months field to indicate odd (1: Jan, 3: Mar...) and even (2: Feb, 4: Apr...) months.</li>
+                                <li><code>O</code> and <code>E</code> can be used in the day of week field to indicate odd and even days of the month.</li>
+                                <li><code>*</code> can be used for any year, month, day of month or day of week.</li>
+                                <li>Examples
+                                    <ul>
+                                        <li><code>*-*-1</code>, first day of each month</li>
+                                        <li><code>*-6-* (1)</code>, all Mondays in June.</li>
+                                        <li><code>*-E-1</code>, first day of all even months.</li>
+                                        <li>
+                                            <code>2024-11-07 (1)</code>, an empty set, because day of week is actually Thursday (4),
+                                            the more straightforward way would be to just leave out this entry where this data would occur.
+                                        </li>
+                                        <li><code>2024-11-07 (4)</code> / <code>2024-11-07</code>, an exact date with or without the day of week.</li>
+                                        <li><code>2024-11-07 (4)</code> / <code>2024-11-07</code>, an exact date with or without the day of week.</li>
+                                        <li><code>*-*-* (*)</code> / <code>*-*-*</code>, any date</li>
+                                    </ul>
+                                </li>
+                            </ul>
                         </td>
                         <td>
                             <code>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -655,8 +655,8 @@ lowercase = %x61-7A  ; "a" to "z"
                             <code>
                                 {
                                     "type": "string",
-                                    "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|O|E\\*)-((3[01]|0[1-9]|[12][0-9])|O|E\\*)(\\s*\\([1-7\\*]\\))?T((2[0-3]|[01][0-9])|\\*):([0-5][0-9]|\\*):([0-5][0-9]|\\*)(\\.[0-9]+)?(Z|[+-]\\d\\d:\\d\\d)?$",
-                                    "$comment": "ISO8601 Date Time Format, optionally extended with day of week (1: Mon, 7: Sun) and wildcards (O, E, *)"
+                                    "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|O|E|\\*)-((3[01]|0[1-9]|[12][0-9])|O|E|\\*)(\\s*\\([1-7\\*]\\))?T((2[0-3]|[01][0-9])|\\*):([0-5][0-9]|\\*):([0-5][0-9]|\\*)(\\.[0-9]+)?(Z|[+-]\\d\\d:\\d\\d)?$",
+                                    "$comment": "A recurrence rule format based on ISO8601, specifies repeating dates and times using year, month, day, hour, minute, second, and optionally day of week (1: Mon, 7: Sun). Supports wildcards: 'O' for odd values, 'E' for even values, and '*' for any valid value in each component."
                                 }
                             </code>
                             <br />
@@ -747,8 +747,8 @@ lowercase = %x61-7A  ; "a" to "z"
                             <code>
                                 {
                                     "type": "string",
-                                    "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|O|E\\*)-((3[01]|0[1-9]|[12][0-9])|O|E\\*)(\\s*\\([1-7\\*]\\))?$",
-                                    "$comment": "ISO8601 Date Format, optionally extended with day of week (1: Mon, 7: Sun) and wildcards (O, E, *)"
+                                    "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|O|E|\\*)-((3[01]|0[1-9]|[12][0-9])|O|E|\\*)(\\s*\\([1-7\\*]\\))?$",
+                                    "$comment": "A recurrence rule format based on ISO8601, specifies repeating dates using year, month, day, and optionally day of week (1: Mon, 7: Sun). Supports wildcards: 'O' for odd days, 'E' for even days, and '*' for any valid value in each component."
                                 }
                             </code>
 
@@ -758,16 +758,14 @@ lowercase = %x61-7A  ; "a" to "z"
                                 <li><code>*</code> can be used for any year, month, day of month or day of week.</li>
                                 <li>Examples
                                     <ul>
-                                        <li><code>*-*-1</code>, first day of each month</li>
-                                        <li><code>*-6-* (1)</code>, all Mondays in June.</li>
-                                        <li><code>*-E-1</code>, first day of all even months.</li>
+                                        <li><code>*-*-01</code>: Recurs on the 1st day of every month, regardless of year.</li>
+                                        <li><code>*-06-* (1)</code>: Recurs on every Monday in June, regardless of year.</li>
+                                        <li><code>*-E-01</code>: Recurs on the 1st day of every even month, regardless of year.</li>
                                         <li>
-                                            <code>2024-11-07 (1)</code>, an empty set, because day of week is actually Thursday (4),
-                                            the more straightforward way would be to just leave out this entry where this data would occur.
+                                            <code>2024-11-07 (1)</code>: November 7, 2024, is not a Monday, resulting in no recurrences.
                                         </li>
-                                        <li><code>2024-11-07 (4)</code> / <code>2024-11-07</code>, an exact date with or without the day of week.</li>
-                                        <li><code>2024-11-07 (4)</code> / <code>2024-11-07</code>, an exact date with or without the day of week.</li>
-                                        <li><code>*-*-* (*)</code> / <code>*-*-*</code>, any date</li>
+                                        <li><code>2024-11-07 (4)</code> / <code>2024-11-07</code>: November 7, 2024, is a Thursday, resulting in a single recurrence.</li>
+                                        <li><code>*-*-* (*)</code> / <code>*-*-*</code>: Recurs every day, regardless of year, month, or day of the week.</li>
                                     </ul>
                                 </li>
                             </ul>
@@ -793,9 +791,12 @@ lowercase = %x61-7A  ; "a" to "z"
                                 }
                             </code>
 
-                            The wildcards are used to indicate occurrences,
-                            e.g. <code>*:00:00Z</code> to indicate all seconds of the first minute of the hour in UTC.
-                            <code>*:*:*</code> can be used to indicate any time.
+                            Examples:
+                            <ul>
+                                <li><code>*:00:00Z</code>: Recurs every hour on the hour (00 minutes, 00 seconds), using Coordinated Universal Time (UTC).</li>
+                                <li><code>*:*:*</code>: Recurs every second of every minute and every hour, essentially occurring continuously throughout the day.</li>
+                                <li><code>06:00:00Z</code>: Occurs at 6:00 AM UTC, with 0 minutes and 0 seconds past the hour.</li>
+                            </ul>
                         </td>
                         <td>
                             <code>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -655,8 +655,8 @@ lowercase = %x61-7A  ; "a" to "z"
                             <code>
                                 {
                                     "type": "string",
-                                    "pattern": "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|\\*)-((3[01]|0[1-9]|[12][0-9])|\\*)T((2[0-3]|[01][0-9])|\\*):([0-5][0-9]|\\*):([0-5][0-9]|\\*)(\\.[0-9]+)?(Z|[+-]\\d\\d:\\d\\d)?$",,
-                                    "$comment": "ISO8601 Date Time Format with optional wildcards"
+                                    "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|\\*)-((3[01]|0[1-9]|[12][0-9])|\\*)(\\s*\\([1-7\\*]\\))?T((2[0-3]|[01][0-9])|\\*):([0-5][0-9]|\\*):([0-5][0-9]|\\*)(\\.[0-9]+)?(Z|[+-]\\d\\d:\\d\\d)?$",
+                                    "$comment": "ISO8601 Date Time Format, extended with day of week (1: Mon, 7: Sun) and with optional wildcards"
                                 }
                             </code>
                         </td>
@@ -745,8 +745,8 @@ lowercase = %x61-7A  ; "a" to "z"
                             <code>
                                 {
                                     "type": "string",
-                                    "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|\\*)-((3[01]|0[1-9]|[12][0-9])|\\*)$",
-                                    "$comment": "ISO8601 Date Format with optional wildcards"
+                                    "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|\\*)-((3[01]|0[1-9]|[12][0-9])|\\*)(\\s*\\([1-7\\*]\\))?$",
+                                    "$comment": "ISO8601 Date Format, extended with day of week (1: Mon, 7: Sun) and with optional wildcards"
                                 }
                             </code>
                         </td>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -787,7 +787,7 @@ lowercase = %x61-7A  ; "a" to "z"
                                 {
                                     "type": "string",
                                     "pattern": "^((2[0-3]|[01][0-9])|\\*):([0-5][0-9]|\\*):([0-5][0-9]|\\*)(\\.[0-9]+)?(Z|[+-]\\d\\d:\\d\\d)?$",
-                                    "$comment": "ISO8601 Time Format with optional wildcards"
+                                    "$comment": "A recurrence rule format based on ISO8601, specifies repeating times using hour, minute, and second. Supports the '*' wildcard for any valid value in each component."
                                 }
                             </code>
 

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -656,7 +656,7 @@ lowercase = %x61-7A  ; "a" to "z"
                                 {
                                     "type": "string",
                                     "pattern": "^((([1-9][0-9]*)?[0-9]{4})|\\*)-((1[0-2]|0[1-9])|O|E\\*)-((3[01]|0[1-9]|[12][0-9])|O|E\\*)(\\s*\\([1-7\\*]\\))?T((2[0-3]|[01][0-9])|\\*):([0-5][0-9]|\\*):([0-5][0-9]|\\*)(\\.[0-9]+)?(Z|[+-]\\d\\d:\\d\\d)?$",
-                                    "$comment": "ISO8601 Date Time Format, optionally extended with day of week (1: Mon, 7: Sun) and with optional wildcards"
+                                    "$comment": "ISO8601 Date Time Format, optionally extended with day of week (1: Mon, 7: Sun) and wildcards (O, E, *)"
                                 }
                             </code>
                             <br />


### PR DESCRIPTION
Without wildcards, day of week would not be necessary, that's why ISO8601 doesn't support day of week in [calendar dates](https://en.wikipedia.org/wiki/ISO_8601#Calendar_dates).

Because BACnet supports wildcards for the dates, we need to represent day of week. This change takes the day of week representation of ISO8601's [week dates](https://en.wikipedia.org/wiki/ISO_8601#Week_dates) and extends the ISO8601's calendar date format with it.