### PR TITLE
chore: downgrade JSON Schema from 2019-09 to draft-07

### DIFF
--- a/bindings/protocols/bacnet/bacnet.schema.json
+++ b/bindings/protocols/bacnet/bacnet.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title":"JSON Schema BACnet for TDs using BACnet Binding",
     "anyOf": [
         {

--- a/bindings/protocols/coap/coap.schema.json
+++ b/bindings/protocols/coap/coap.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "anyOf": [
         {
             "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"

--- a/bindings/protocols/http/http.schema.json
+++ b/bindings/protocols/http/http.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "anyOf": [
         {
             "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"

--- a/bindings/protocols/modbus/modbus.schema.json
+++ b/bindings/protocols/modbus/modbus.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "anyOf": [
         {
             "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"

--- a/bindings/protocols/mqtt/mqtt.schema.json
+++ b/bindings/protocols/mqtt/mqtt.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "anyOf": [
         {
             "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"

--- a/bindings/protocols/template.schema.json
+++ b/bindings/protocols/template.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "anyOf": [
         {
             "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"


### PR DESCRIPTION
wot-thing-description repo uses draft-07, as well; and 2019-09 is not well-supported in implementations. In TD 2.0 we should switch to 2020-12.

https://github.com/w3c/wot-thing-description/issues/1017