### PR TITLE
fix: model BACnet relinquish explicitly

### DIFF
--- a/bindings/protocols/bacnet/bacnet-model.ttl
+++ b/bindings/protocols/bacnet/bacnet-model.ttl
@@ -43,7 +43,7 @@ Wherever possible, this model refers to ANSI/ASHRAE Standard 135-2020 for BACnet
 
 hctl:hasTarget rdfs:comment """
 Should be of form bacnet://<device>/<objecttypenr>,<objectinsttr>[/<property>[/<index>]]
-Additional parameters can be specified via URI variable syntax, e.g. ?commandPriority=13 for command priority, ?relinquish for relinquishing a priority or ?covIncrement=0.5 for COV increment
+Additional parameters can be specified via URI variable syntax, e.g., `?commandPriority=13` to change command priority, `?relinquish` to relinquish a priority, or `?covIncrement=0.5` to increment COV.
 """@en ;
                rdfs:seeAlso "ASHRAE 135-2020 BACnet Q.8 BACnet URI Scheme" .
 
@@ -103,7 +103,7 @@ bacv:CommandPriority rdf:type owl:Class ;
                            # Default priority for writing is 16, ref. ASHRAE 135-2020 BACnet 15.9.1.1.5 Priority
                            owl:hasValue 16
                        ] ;
-                       rdfs:comment "Specifies the writing priority for BACnet objects with commanding, i.e. priority array."@en ;
+                       rdfs:comment "Specifies the writing priority for BACnet objects with commanding, i.e., priority array."@en ;
                        rdfs:seeAlso "ASHRAE 135-2020 BACnet 19.2 Command Prioritization" .
 
 bacv:Relinquish rdf:type owl:Class ;

--- a/bindings/protocols/bacnet/bacnet-model.ttl
+++ b/bindings/protocols/bacnet/bacnet-model.ttl
@@ -43,7 +43,7 @@ Wherever possible, this model refers to ANSI/ASHRAE Standard 135-2020 for BACnet
 
 hctl:hasTarget rdfs:comment """
 Should be of form bacnet://<device>/<objecttypenr>,<objectinsttr>[/<property>[/<index>]]
-Additional parameters can be specified via URI variable syntax, e.g. ?commandPriority=13 for command priority or ?covIncrement=0.5 for COV increment
+Additional parameters can be specified via URI variable syntax, e.g. ?commandPriority=13 for command priority, ?relinquish for relinquishing a priority or ?covIncrement=0.5 for COV increment
 """@en ;
                rdfs:seeAlso "ASHRAE 135-2020 BACnet Q.8 BACnet URI Scheme" .
 
@@ -105,6 +105,16 @@ bacv:CommandPriority rdf:type owl:Class ;
                        ] ;
                        rdfs:comment "Specifies the writing priority for BACnet objects with commanding, i.e. priority array."@en ;
                        rdfs:seeAlso "ASHRAE 135-2020 BACnet 19.2 Command Prioritization" .
+
+bacv:Relinquish rdf:type owl:Class ;
+                rdfs:subClassOf jsonschema:BooleanSchema ;
+                rdfs:subClassOf [
+                    a owl:Restriction ;
+                    owl:onProperty jsonschema:default ;
+                    owl:hasValue false
+                ] ;
+                rdfs:comment "Specifies that the value at this priority should be deleted/relinquished by writing NULL to this priority."@en ;
+                rdfs:seeAlso "ASHRAE 135-2020 BACnet 19.2 Command Prioritization" .
 
 #################################################################
 #    Type information properties

--- a/bindings/protocols/bacnet/bacnet.schema.json
+++ b/bindings/protocols/bacnet/bacnet.schema.json
@@ -252,6 +252,10 @@
             "enum": [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             "default": 16
         },
+        "relinquish": {
+            "type": "boolean",
+            "default": false
+        },
         "eventPayload": {
             "type": "object",
             "properties": {

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -371,6 +371,14 @@ lowercase = %x61-7A  ; "a" to "z"
                         </td>
                     </tr>
                     <tr>
+                        <td><code>relinquish</code></td>
+                        <td>Indicates that the value at this priority should be deleted/relinquished</td>
+                        <td>optional</td>
+                        <td>
+                            <a href="https://www.w3.org/2019/wot/json-schema#BooleanSchema"><code>boolean</code></a>
+                        </td>
+                    </tr>
+                    <tr>
                         <td><code>covIncrement</code></td>
                         <td>Sets COV increment change for reporting via SubscribeCOVProperty (SubscribeCOV with a
                             property ID)</td>
@@ -387,7 +395,7 @@ lowercase = %x61-7A  ; "a" to "z"
             </p>
             <p>
                 The following JSON example shows the usage of the BACnet vocabulary for URI Variables, specifically
-                CommandPriority and CovIncrement. The semantic annotation is optional.
+                commandPriority, relinquish and covIncrement. The semantic annotation is optional.
             </p>
             <p>
                 This template could be used to construct the uriVariables element for TD interaction affordances, to
@@ -425,6 +433,11 @@ lowercase = %x61-7A  ; "a" to "z"
             "@type": "bacv:CovIncrement",
             "type": "number",
             "minimum": 0
+        },
+        "relinquish": {
+            "@type": "bacv:Relinquish",
+            "type": "boolean",
+            "default": false
         }
     }  
 }
@@ -449,7 +462,8 @@ lowercase = %x61-7A  ; "a" to "z"
                             <a
                                 href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
                             <p>(one of <code>"ReadProperty"</code>, <code>"WriteProperty"</code>,
-                                <code>"SubscribeCOV"</code>, <code>"GetEventInfo"</code>, <code>"AcknowledgeAlarm"</code>,
+                                <code>"SubscribeCOV"</code>, <code>"GetEventInfo"</code>,
+                                <code>"AcknowledgeAlarm"</code>,
                                 <code>"AddListElement"</code>, <code>"RemoveListElement"</code>)
                             </p>
                         </td>
@@ -583,7 +597,7 @@ lowercase = %x61-7A  ; "a" to "z"
                     <tr>
                         <td><code>writeproperty</code></td>
                         <td><code>"bacv:usesService": "WriteProperty"</code></td>
-                        <td>CommandPriority</td>
+                        <td>commandPriority, relinquish</td>
                     </tr>
                     <tr>
                         <td><code>observeproperty</code></td>
@@ -1396,15 +1410,22 @@ lowercase = %x61-7A  ; "a" to "z"
         <p>
             [[[#example-uri-variable-for-writing]]] demonstrates how the <code>uriVariable</code> in the
             affordance-level can be used to model a writing priority in a <code>forms</code> element.
-            The <code>"bacv:commandPriority"</code> indicates that the URI variable set by the Consumer application will
-            be relayed as the priority argument in the WriteProperty request.
-            For other operations (readproperty, observeproperty, unobserveproperty) this URI variable is irrelevant, so the corresponding forms do not use the URI variable.
-            If the URI variable is also irrelevant for the writeproperty operation (e.g., when the BACnet object doesn't have a priority array),
-            it can also be left out of the writeproperty form and the URI variable can be omitted completely.
-            The URI variable comes with a default, so if the Consumer doesn't provide this URI variable, the default of 16 will be used.
+            The <code>"bacv:CommandPriority"</code> indicates that the URI variable set by the Consumer application will
+            be relayed as the priority argument in the WriteProperty request. And <code>"bacv:Relinquish"</code> indicates if the user wants to relinquish the property value at the given command priority.
+            For other operations (readproperty, observeproperty, unobserveproperty) these URI variables are irrelevant, so the corresponding forms do not use them.
+            If the URI variables are also irrelevant for the writeproperty operation (e.g., when the BACnet object doesn't have a priority array),
+            they can also be left out of the writeproperty form and the URI variables can be omitted completely.
+            The URI variables come with defaults, so if the Consumer doesn't provide them, the defaults of writePriority=16 and relinquish=false will be used.
             Another possibility is to fix the writing priority in the TD by giving a fixed commandPriority in the <code>href</code> of the form, and not exposing its value via a URI variable.
             These decisions belong to the TD author.
         </p>
+
+        <div class="note">
+            <p>
+                When relinquish is set to true, WoT consumer will ignore the value given to the writeproperty operation and write NULL instead. This clears the value at the specified priority,
+                and is the only way of allowing a lower priority to take effect.
+            </p>
+        </div>
 
         <pre id="example-uri-variable-for-writing" class="example"
             title="uriVariables in the Affordance Level for writing">
@@ -1422,10 +1443,15 @@ lowercase = %x61-7A  ; "a" to "z"
                         "observable": true,
                         "uriVariables": {
                             "writePriority": {
-                                "@type": "bacv:commandPriority",
+                                "@type": "bacv:CommandPriority",
                                 "type": "integer",
                                 "enum": [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                                 "default": 16
+                            },
+                            "relinquish": {
+                                "@type": "bacv:Relinquish",
+                                "type": "boolean",
+                                "default": false
                             }
                         },
                         "forms": [
@@ -1439,7 +1465,7 @@ lowercase = %x61-7A  ; "a" to "z"
                             },
                             {
                                 "op": [ "writeproperty" ],
-                                "href": "bacnet://5/2,1?commandPriority={writePriority}",
+                                "href": "bacnet://5/2,1?commandPriority={writePriority}{&relinquish}",
                                 "contentType": "application/octet-stream",
                                 "bacv:usesService": "WriteProperty",
                                 "bacv:hasDataType": {

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1423,7 +1423,7 @@ lowercase = %x61-7A  ; "a" to "z"
 
         <div class="note">
             <p>
-                When relinquish is set to true, WoT consumer will ignore the value given to the writeproperty operation and write NULL instead. This clears the value at the specified priority,
+                When relinquish is set to `true`, WoT consumer will ignore the value given to the `writeproperty` operation and write `NULL` instead. This clears the value at the specified priority,
                 and is the only way of allowing a lower priority to take effect.
             </p>
         </div>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -395,7 +395,7 @@ lowercase = %x61-7A  ; "a" to "z"
             </p>
             <p>
                 The following JSON example shows the usage of the BACnet vocabulary for URI Variables, specifically
-                commandPriority, relinquish and covIncrement. The semantic annotation is optional.
+                commandPriority, relinquish, and covIncrement. The semantic annotation is optional.
             </p>
             <p>
                 This template could be used to construct the uriVariables element for TD interaction affordances, to
@@ -1411,12 +1411,13 @@ lowercase = %x61-7A  ; "a" to "z"
             [[[#example-uri-variable-for-writing]]] demonstrates how the <code>uriVariable</code> in the
             affordance-level can be used to model a writing priority in a <code>forms</code> element.
             The <code>"bacv:CommandPriority"</code> indicates that the URI variable set by the Consumer application will
-            be relayed as the priority argument in the WriteProperty request. And <code>"bacv:Relinquish"</code> indicates if the user wants to relinquish the property value at the given command priority.
-            For other operations (readproperty, observeproperty, unobserveproperty) these URI variables are irrelevant, so the corresponding forms do not use them.
-            If the URI variables are also irrelevant for the writeproperty operation (e.g., when the BACnet object doesn't have a priority array),
-            they can also be left out of the writeproperty form and the URI variables can be omitted completely.
-            The URI variables come with defaults, so if the Consumer doesn't provide them, the defaults of writePriority=16 and relinquish=false will be used.
-            Another possibility is to fix the writing priority in the TD by giving a fixed commandPriority in the <code>href</code> of the form, and not exposing its value via a URI variable.
+            be relayed as the priority argument in the WriteProperty request. <code>"bacv:Relinquish"</code> indicates whether the user wants to relinquish the property value at the given command priority.
+            For other operations (e.g., `readproperty`, `observeproperty`, `unobserveproperty`) these URI variables are irrelevant, so the corresponding forms do not use them.
+            If the URI variables are also irrelevant for the `writeproperty` operation (e.g., when the BACnet object doesn't have a priority array),
+            they can also be left out of the `writeproperty` form, and the URI variables can be omitted completely.
+            The URI variables come with defaults,
+            so if the Consumer doesn't provide them, the defaults of `writePriority=16` and `relinquish=false` will be used.
+            Another possibility is to fix the writing priority in the TD by giving a fixed `commandPriority` in the <code>href</code> of the form, and not exposing its value via a URI variable.
             These decisions belong to the TD author.
         </p>
 

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1423,7 +1423,7 @@ lowercase = %x61-7A  ; "a" to "z"
 
         <div class="note">
             <p>
-                When relinquish is set to `true`, WoT consumer will ignore the value given to the `writeproperty` operation and write `NULL` instead. This clears the value at the specified priority,
+                When relinquish is set to <code>true</code>, WoT consumer will ignore the value given to the <code>writeproperty</code> operation and write <code>NULL</code> instead. This clears the value at the specified priority,
                 and is the only way of allowing a lower priority to take effect.
             </p>
         </div>

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -1412,12 +1412,12 @@ lowercase = %x61-7A  ; "a" to "z"
             affordance-level can be used to model a writing priority in a <code>forms</code> element.
             The <code>"bacv:CommandPriority"</code> indicates that the URI variable set by the Consumer application will
             be relayed as the priority argument in the WriteProperty request. <code>"bacv:Relinquish"</code> indicates whether the user wants to relinquish the property value at the given command priority.
-            For other operations (e.g., `readproperty`, `observeproperty`, `unobserveproperty`) these URI variables are irrelevant, so the corresponding forms do not use them.
-            If the URI variables are also irrelevant for the `writeproperty` operation (e.g., when the BACnet object doesn't have a priority array),
-            they can also be left out of the `writeproperty` form, and the URI variables can be omitted completely.
+            For other operations (e.g., <code>readproperty</code>, <code>observeproperty</code>, <code>unobserveproperty</code>) these URI variables are irrelevant, so the corresponding forms do not use them.
+            If the URI variables are also irrelevant for the <code>writeproperty</code> operation (e.g., when the BACnet object doesn't have a priority array),
+            they can also be left out of the <code>writeproperty</code> form, and the URI variables can be omitted completely.
             The URI variables come with defaults,
-            so if the Consumer doesn't provide them, the defaults of `writePriority=16` and `relinquish=false` will be used.
-            Another possibility is to fix the writing priority in the TD by giving a fixed `commandPriority` in the <code>href</code> of the form, and not exposing its value via a URI variable.
+            so if the Consumer doesn't provide them, the defaults of <code>writePriority=16</code> and <code>relinquish=false</code> will be used.
+            Another possibility is to fix the writing priority in the TD by giving a fixed <code>commandPriority</code> in the <code>href</code> of the form, and not exposing its value via a URI variable.
             These decisions belong to the TD author.
         </p>
 


### PR DESCRIPTION
So far we hadn't modelled the relinquish operation explicitly, which is problematic as it requires the WoT consumer to write null to a PropertyAffordance to clear a priority, even though its DataSchema doesn't allow it.

Options I've evaluated:

1. Leave AS IS -> implicit knowledge of the WoT Consumer is needed
2. Make the PropertyAffordance schema as { oneOf: null or number } ->This would imply that the value could be null when reading or observing, which is wrong.
3. Add another URI variable relinquish: boolean. -> This PR's solution, even though it still requires a dummy write value to be provided, which will be ignored
4. Using ActionAffordance -> creates unnecessary dual entities of the same BACnet Object, and the WoT Consumers needs to deal with the complexity of handling that they deal with the same entity. Additionally it doesn't gracefully handle WoT Consumers that call writeproperty without a priority.

@egekorkan @ektrah @mjkoster please have a look.