### PR TITLE
fix: BACnet JSON Schema syntax corrections

### DIFF
--- a/bindings/protocols/bacnet/bacnet.schema.json
+++ b/bindings/protocols/bacnet/bacnet.schema.json
@@ -326,10 +326,10 @@
                 "items": {
                   "$ref": "#/definitions/eventPayload"
                 }
+              },
+              "moreEvents": {
+                "type": "boolean"
               }
-            },
-            "moreEvents": {
-              "type": "boolean"
             },
             "required": [
               "currentEvents",
@@ -363,9 +363,9 @@
                   "ackTime": {
                     "type": "string",
                     "format": "date-time"
-                  },
-                  "required": ["source", "ackState", "eventTime", "ackSource", "ackTime"]
-            }
+                  }
+            },
+            "required": ["source", "ackState", "eventTime", "ackSource", "ackTime"]
         },
         "affordance": {
             "type": "object",


### PR DESCRIPTION
Syntax corrections:

1. moreEvents should be in the properties of the action_output_getCurrentEvents object
2. action_input_acknowledgeEvent's required should not be under the properties

