### PR TITLE
docs(BACnet): remark why data link layers are left out

### DIFF
--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -161,9 +161,9 @@
       <p>
         This binding leaves out BACnet data link layer details (e.g. IP, MS/TP, Secure Connect), as the BACnet device
         identifier provides sufficient addressing in a properly configured network. This approach avoids complexities
-        that arise such as when WoT consumer and WoT thing use different data links connected via BACnet routers.
-        This design philosophy mirrors the HTTP protocol binding, which focuses on HTTP semantics
-        rather than underlying IP infrastructure such as routing and name resolution.
+        that arise such as when WoT consumer and WoT thing use different data links connected via BACnet routers. This
+        design philosophy mirrors the HTTP protocol binding, which focuses on HTTP semantics rather than underlying IP
+        infrastructure such as routing and name resolution.
       </p>
       <p>
         WoT Interaction Affordances are mapped to BACnet Properties. If the BACnet property-identifier is not present in

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -161,9 +161,9 @@
       <p>
         This binding leaves out BACnet data link layer details (e.g. IP, MS/TP, Secure Connect), as the BACnet device
         identifier provides sufficient addressing in a properly configured network. This approach avoids complexities
-        that arise such as when WoT consumer and WoT thing use different data links connected via BACnet routers. This
+        that arise, such as when WoT consumer and WoT thing use different data links connected via BACnet routers. This
         design philosophy mirrors the HTTP protocol binding, which focuses on HTTP semantics rather than underlying IP
-        infrastructure such as routing and name resolution.
+        infrastructure, such as routing and name resolution.
       </p>
       <p>
         WoT Interaction Affordances are mapped to BACnet Properties. If the BACnet property-identifier is not present in

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -159,7 +159,7 @@
         onboarding, or device management.
       </p>
       <p>
-        This binding leaves out BACnet data link layer details (e.g. IP, MS/TP, Secure Connect), as the BACnet device
+        This binding leaves out BACnet data link layer details (e.g., IP, MS/TP, Secure Connect), as the BACnet device
         identifier provides sufficient addressing in a properly configured network. This approach avoids complexities
         that arise, such as when WoT consumer and WoT thing use different data links connected via BACnet routers. This
         design philosophy mirrors the HTTP protocol binding, which focuses on HTTP semantics rather than underlying IP

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -159,6 +159,13 @@
         onboarding, or device management.
       </p>
       <p>
+        This binding leaves out BACnet data link layer details (e.g. IP, MS/TP, Secure Connect), as the BACnet device
+        identifier provides sufficient addressing in a properly configured network. This approach avoids complexities
+        that arise such as when WoT consumer and WoT thing use different data links connected via BACnet routers.
+        This design philosophy mirrors the HTTP protocol binding, which focuses on HTTP semantics
+        rather than underlying IP infrastructure such as routing and name resolution.
+      </p>
+      <p>
         WoT Interaction Affordances are mapped to BACnet Properties. If the BACnet property-identifier is not present in
         the URI element of the form, the object-identifier is used to interact with the BACnet Object, exposing the
         present-value Property.


### PR DESCRIPTION
This is already our design, so no change in content. It is helpful for readers looking for data link layer specifics in this binding.