### PR TITLE
Modbus: typo in template.sparql

### DIFF
--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -568,6 +568,55 @@
           </thead>
           <tbody>
             <!-- Generate mappings from the mapping ontology -->
+
+            <tr>
+              <td><code>readproperty</code></td>
+              <td><code>"modv:Function": "readCoil"</code></td>
+            </tr>
+
+            <tr></tr>
+
+            <tr>
+              <td><code>writeproperty</code></td>
+              <td><code>"modv:Function": "writeSingleCoil"</code></td>
+            </tr>
+
+            <tr></tr>
+
+            <tr>
+              <td><code>invokeaction</code></td>
+              <td><code>"modv:Function": "writeSingleCoil"</code></td>
+            </tr>
+
+            <tr></tr>
+
+            <tr>
+              <td><code>readallproperties</code></td>
+              <td><code>"modv:Function": "readHoldingRegisters"</code></td>
+            </tr>
+
+            <tr></tr>
+
+            <tr>
+              <td><code>readmultipleproperties</code></td>
+              <td><code>"modv:Function": "readHoldingRegisters"</code></td>
+            </tr>
+
+            <tr></tr>
+
+            <tr>
+              <td><code>writeallproperties</code></td>
+              <td><code>"modv:Function": "writeMultipleHoldingRegisters"</code></td>
+            </tr>
+
+            <tr></tr>
+
+            <tr>
+              <td><code>writemultipleproperties</code></td>
+              <td><code>"modv:Function": "writeMultipleHoldingRegisters"</code></td>
+            </tr>
+
+            <tr></tr>
           </tbody>
         </table>
         The next table defines default values for other terms, regardless of their use in combination with one of the

--- a/bindings/protocols/modbus/mapping.ttl
+++ b/bindings/protocols/modbus/mapping.ttl
@@ -97,7 +97,7 @@
         sh:path hctl:hasOperationType ;
         sh:hasValue td:readProperty
     ], [
-        sh:path modv:hasFunction ;
+        sh:path modv:Function ;
         sh:defaultValue modv:readCoil
     ] .
 :WriteModubsPropertyForm a sh:NodeShape ;

--- a/bindings/protocols/modbus/template.sparql
+++ b/bindings/protocols/modbus/template.sparql
@@ -157,7 +157,7 @@ template :mappings(?ns ?prefix){
         sh:defaultValue ?default.
    
    filter( ?index > 1 )
-    bind(IRI(CONCAT(STR( ?ns),"#function")) as ?modbusFunction)
+    bind(IRI(CONCAT(STR( ?ns),"#Function")) as ?modbusFunction)
 }
 
 template :entityValues(?ns ?prefix){


### PR DESCRIPTION
function -> Function. Fixed also hasFunction -> Function in mapping.ttl.

fixes #460