### PR TITLE
TD Schema Reference Fix

### DIFF
--- a/bindings/protocols/bacnet/bacnet.schema.json
+++ b/bindings/protocols/bacnet/bacnet.schema.json
@@ -3,7 +3,7 @@
   "title": "JSON Schema BACnet for TDs using BACnet Binding",
   "anyOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"
+      "$ref": "https://www.w3.org/2022/wot/td-schema/v1.1"
     }
   ],
   "definitions": {

--- a/bindings/protocols/coap/coap.schema.json
+++ b/bindings/protocols/coap/coap.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "anyOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"
+      "$ref": "https://www.w3.org/2022/wot/td-schema/v1.1"
     }
   ],
   "definitions": {

--- a/bindings/protocols/http/http.schema.json
+++ b/bindings/protocols/http/http.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "anyOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"
+      "$ref": "https://www.w3.org/2022/wot/td-schema/v1.1"
     }
   ],
   "definitions": {

--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -833,7 +833,7 @@
                   "@context": [
                       "https://www.w3.org/2019/wot/td/v1",
                       {
-                          "modv": "https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/context.jsonld"
+                          "modv": "https://www.w3.org/2019/wot/modbus"
                       }
                   ],
                   "title": "ModbusPLC",
@@ -904,7 +904,7 @@
                                   ],
                                   "href": "3",
                                   "modv:entity": "Coil",
-                                  "modv:pollingRate": 100,
+                                  "modv:pollingTime": 100,
                                   "contentType": "application/octet-stream"
                               }
                           ]

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -518,7 +518,7 @@
                   "@context": [
                       "https://www.w3.org/2019/wot/td/v1",
                       {
-                          "modv": "https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/context.jsonld"
+                          "modv": "https://www.w3.org/2019/wot/modbus"
                       }
                   ],
                   "title": "ModbusPLC",
@@ -589,7 +589,7 @@
                                   ],
                                   "href": "3",
                                   "modv:entity": "Coil",
-                                  "modv:pollingRate": 100,
+                                  "modv:pollingTime": 100,
                                   "contentType": "application/octet-stream"
                               }
                           ]

--- a/bindings/protocols/modbus/modbus.schema.json
+++ b/bindings/protocols/modbus/modbus.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "anyOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"
+      "$ref": "https://www.w3.org/2022/wot/td-schema/v1.1"
     }
   ],
   "definitions": {

--- a/bindings/protocols/mqtt/mqtt.schema.json
+++ b/bindings/protocols/mqtt/mqtt.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "anyOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"
+      "$ref": "https://www.w3.org/2022/wot/td-schema/v1.1"
     }
   ],
   "definitions": {

--- a/bindings/protocols/profinet/profinet.schema.json
+++ b/bindings/protocols/profinet/profinet.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "anyOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"
+      "$ref": "https://www.w3.org/2022/wot/td-schema/v1.1"
     }
   ],
   "definitions": {

--- a/bindings/protocols/template.schema.json
+++ b/bindings/protocols/template.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "anyOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json"
+      "$ref": "https://www.w3.org/2022/wot/td-schema/v1.1"
     }
   ],
   "definitions": {


### PR DESCRIPTION
All the schemas were referring to the main branch schema in the TD repo. That is subject to breaking changes. I am fixing to the stable link.

Additionally, one modbus example was using `pollingRate` instead of `pollingTime` and the context URI in modbus was the github.io URL. While that is correct, it is not used anywhere else and would cause issues somewhere in the end.