### PR TITLE
Deprecating zeroBasedAddressing

### DIFF
--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -284,8 +284,12 @@
             <tr>
               <td><code>modv:zeroBasedAddressing</code></td>
               <td>
-                Modbus implementations can differ in the way addressing works, as the first coil/register can be either
-                referred to as <code>true</code> or <code>false</code>.
+                DEPRECATED as TDs are expected to contain the address to be directly used by the Consumer
+                implementation. See also
+                <a href="https://github.com/w3c/wot-binding-templates/issues/187">the relevant issue</a>. Previous
+                explanation:Modbus implementations can differ in the way addressing works, as the first coil/register
+                can be either referred to as <code>true</code> or <code>false</code>. False when the first register
+                starts at address 1.
               </td>
               <td>optional</td>
               <td><a href="http://www.w3.org/2001/XMLSchema#boolean">boolean</a></td>
@@ -642,7 +646,7 @@
               <td>
                 <code>false</code>
               </td>
-              <td></td>
+              <td>The term is deprecated and should not be used anymore.</td>
             </tr>
             <tr>
               <td><code>modv:mostSignificantByte</code></td>

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -327,7 +327,7 @@
               <td>
                 <code>false</code>
               </td>
-              <td></td>
+              <td>The term is deprecated and should not be used anymore.</td>
             </tr>
             <tr>
               <td><code>modv:mostSignificantByte</code></td>

--- a/bindings/protocols/modbus/modbus.schema.json
+++ b/bindings/protocols/modbus/modbus.schema.json
@@ -50,7 +50,7 @@
         },
         "modv:mostSignificantByte": { "type": "boolean" },
         "modv:mostSignificantWord": { "type": "boolean" },
-        "modv:zeroBasedAddressing": { "type": "boolean" },
+        "modv:zeroBasedAddressing": { "type": "boolean", "$comment": "Deprecated. Please refrain from using." },
         "modv:timeout": { "type": "number", "minimum": 0 }
       }
     },

--- a/bindings/protocols/modbus/ontology.html
+++ b/bindings/protocols/modbus/ontology.html
@@ -625,9 +625,12 @@
           <h4>hasZeroBasedAddressingFlag</h4>
           <p>IRI: <code>https://www.w3.org/2019/wot/modbus#hasZeroBasedAddressingFlag</code></p>
           <span
-            >Modbus implementations can differ in the way addressing works, as the first coil/register can be either
-            referred to as <code>true</code> or <code>false</code>.</span
-          >
+            >DEPRECATED as TDs are expected to contain the address to be directly used by the Consumer implementation.
+            See also <a href="https://github.com/w3c/wot-binding-templates/issues/187">the relevant issue</a>. Previous
+            explanation:Modbus implementations can differ in the way addressing works, as the first coil/register can be
+            either referred to as <code>true</code> or <code>false</code>. False when the first register starts at
+            address 1.
+          </span>
           <table class="def">
             <tbody>
               <tr>

--- a/bindings/protocols/modbus/ontology.ttl
+++ b/bindings/protocols/modbus/ontology.ttl
@@ -195,7 +195,7 @@ binding:assignment rdf:type owl:AnnotationProperty .
 :hasZeroBasedAddressingFlag rdf:type owl:DatatypeProperty ;
                             rdfs:domain :Request ;
                             rdfs:range xsd:boolean ;
-                            rdfs:comment "Modbus implementations can differ in the way addressing works, as the first coil/register can be either referred to as <code>true</code> or <code>false</code>."@en ;
+                            rdfs:comment "DEPRECATED as TDs are expected to contain the address to be directly used by the Consumer implementation. See also <a href=\"https://github.com/w3c/wot-binding-templates/issues/187\">the relevant issue</a>. Previous explanation:Modbus implementations can differ in the way addressing works, as the first coil/register can be either referred to as <code>true</code> or <code>false</code>. False when the first register starts at address 1. "@en ;
                             rdfs:label "hasZeroBasedAddressingFlag"@en .
 
 :hasMostSignificantByte rdf:type owl:DatatypeProperty ;
@@ -254,7 +254,7 @@ binding:assignment rdf:type owl:AnnotationProperty .
           rdfs:comment "Function code identifies the operation requested by client, indicates to the server what kind of action to perform. For a normal response, the server simply echoes to the request the original function code."@en ;
           rdfs:label "Function"@en .
 
-        
+
 ###  https://www.w3.org/2019/wot/modbus#PayloadDataType
 :PayloadDataType rdf:type owl:Class ;
           owl:equivalentClass [ rdf:type owl:Class ;
@@ -283,7 +283,7 @@ binding:assignment rdf:type owl:AnnotationProperty .
 :FunctionField rdf:type owl:Class ;
                 rdfs:subClassOf :Payload ;
                 rdfs:comment """Function Field class represents the value of the function in a Modbus frame. Each operation identified with a human readable name have a corresponding code.
-The response function code corresponds exactly to the request function code sent by the client when no error occurs. 
+The response function code corresponds exactly to the request function code sent by the client when no error occurs.
 On the contrary, the response operation is identified with an error code or exception function code corresponding to the request function code + 0x80."""@en ;
                 rdfs:label "Function Field" .
 
@@ -334,7 +334,7 @@ On the contrary, the response operation is identified with an error code or exce
 ###  https://www.w3.org/2019/wot/modbus#DataRequest
 :DataRequest rdf:type owl:Class ;
               rdfs:subClassOf :DataField ;
-              rdfs:comment """Data request contains additional information sent from a client to server that the server uses to take the action defined by the function code. 
+              rdfs:comment """Data request contains additional information sent from a client to server that the server uses to take the action defined by the function code.
 This can include items like register address, the quantity of items to be handled, and the count of actual data bytes in the field.
 
 The data request field may be nonexistent (zero length) in certain kind of requests, in this case the server does not require any additional information. The function code alone specifies the action."""@en ;

--- a/bindings/protocols/modbus/ontology.ttl
+++ b/bindings/protocols/modbus/ontology.ttl
@@ -195,7 +195,7 @@ binding:assignment rdf:type owl:AnnotationProperty .
 :hasZeroBasedAddressingFlag rdf:type owl:DatatypeProperty ;
                             rdfs:domain :Request ;
                             rdfs:range xsd:boolean ;
-                            rdfs:comment "DEPRECATED as TDs are expected to contain the address to be directly used by the Consumer implementation. See also <a href=\"https://github.com/w3c/wot-binding-templates/issues/187\">the relevant issue</a>. Previous explanation:Modbus implementations can differ in the way addressing works, as the first coil/register can be either referred to as <code>true</code> or <code>false</code>. False when the first register starts at address 1. "@en ;
+                            rdfs:comment "DEPRECATED as TDs are expected to contain the address to be directly used by the Consumer implementation. See also <a href=\"https://github.com/w3c/wot-binding-templates/issues/187\">the relevant issue</a>. Previous explanation: Modbus implementations can differ in the way addressing works, as the first coil/register can be either referred to as <code>true</code> or <code>false</code>. False when the first register starts at address 1. "@en ;
                             rdfs:label "hasZeroBasedAddressingFlag"@en .
 
 :hasMostSignificantByte rdf:type owl:DatatypeProperty ;


### PR DESCRIPTION
fixes #187 . I am not removing it yet though. Just deprecation notice in ontology, text and json schema. As of JSON Schema 2019-09, you can also put `"deprecated":true`