### PR TITLE
Binding registry config in Respec

### DIFF
--- a/bindings/index.template.html
+++ b/bindings/index.template.html
@@ -47,12 +47,11 @@
         ],
         localBiblio: {
           "WOT-BINDING-REGISTRY": {
-            title: "Web of Things (WoT) Bindings Registry",
-            //, href: "https://www.w3.org/TR/wot-binding-registry/"
-            href: "https://w3c.github.io/wot-binding-registry/",
+            title: "Web of Things (WoT) Binding Registry",
+            href: "https://www.w3.org/TR/wot-binding-registry/",
             authors: ["Ege Korkan"],
             publisher: "W3C",
-            date: "TODO" //TODO: Add publication date
+            date: "November 2025"
           }
         }
       };

--- a/bindings/protocols/bacnet/index.html
+++ b/bindings/protocols/bacnet/index.html
@@ -47,11 +47,10 @@
           },
           "WOT-BINDING-REGISTRY": {
             title: "Web of Things (WoT) Binding Registry",
-            // href: "https://www.w3.org/TR/wot-binding-registry/",
-            href: "https://w3c.github.io/wot-binding-registry/",
+            href: "https://www.w3.org/TR/wot-binding-registry/",
             authors: ["Ege Korkan"],
             publisher: "W3C",
-            date: "TODO" //TODO: Add publication date
+            date: "November 2025"
           }
         },
         otherLinks: [
@@ -436,7 +435,7 @@ lowercase = %x61-7A  ; "a" to "z"
             "type": "boolean",
             "default": false
         }
-    }  
+    }
 }
             </pre
         >

--- a/bindings/protocols/coap/index.html
+++ b/bindings/protocols/coap/index.html
@@ -44,11 +44,10 @@
           },
           "WOT-BINDING-REGISTRY": {
             title: "Web of Things (WoT) Binding Registry",
-            // href: "https://www.w3.org/TR/wot-binding-registry/",
-            href: "https://w3c.github.io/wot-binding-registry/",
+            href: "https://www.w3.org/TR/wot-binding-registry/",
             authors: ["Ege Korkan"],
             publisher: "W3C",
-            date: "TODO" //TODO: Add publication date
+            date: "November 2025"
           }
         },
         otherLinks: [

--- a/bindings/protocols/coap/index.template.html
+++ b/bindings/protocols/coap/index.template.html
@@ -44,11 +44,10 @@
           },
           "WOT-BINDING-REGISTRY": {
             title: "Web of Things (WoT) Binding Registry",
-            // href: "https://www.w3.org/TR/wot-binding-registry/",
-            href: "https://w3c.github.io/wot-binding-registry/",
+            href: "https://www.w3.org/TR/wot-binding-registry/",
             authors: ["Ege Korkan"],
             publisher: "W3C",
-            date: "TODO" //TODO: Add publication date
+            date: "November 2025"
           }
         },
         otherLinks: [

--- a/bindings/protocols/http/index.html
+++ b/bindings/protocols/http/index.html
@@ -66,11 +66,10 @@
         localBiblio: {
           "WOT-BINDING-REGISTRY": {
             title: "Web of Things (WoT) Binding Registry",
-            //, href: "https://www.w3.org/TR/wot-binding-registry/"
-            href: "https://w3c.github.io/wot-binding-registry/",
+            href: "https://www.w3.org/TR/wot-binding-registry/",
             authors: ["Ege Korkan"],
             publisher: "W3C",
-            date: "TODO" //TODO: Add publication date
+            date: "November 2025"
           }
         }
       };
@@ -297,7 +296,7 @@
 
         <pre class="example" id="binding-http-usage-1" title="TD with HTTP vocabulary included in @context">
 {
-  "@context": ["https://www.w3.org/ns/wot-next/td", 
+  "@context": ["https://www.w3.org/ns/wot-next/td",
     {"htv":"http://www.w3.org/2011/http#"}
   ],
   "id": "urn:uuid:9cd44eef-0b3f-4566-94b0-1358af3d86bd",

--- a/bindings/protocols/lorawan/index.html
+++ b/bindings/protocols/lorawan/index.html
@@ -72,10 +72,10 @@
         localBiblio: {
           "WOT-BINDING-REGISTRY": {
             title: "Web of Things (WoT) Binding Registry",
-            href: "https://w3c.github.io/wot-binding-registry/",
+            href: "https://www.w3.org/TR/wot-binding-registry/",
             authors: ["Ege Korkan"],
             publisher: "W3C",
-            date: "TODO"
+            date: "November 2025"
           },
           LORAWAN: {
             title: "LoRaWAN Specification",

--- a/bindings/protocols/modbus/index.html
+++ b/bindings/protocols/modbus/index.html
@@ -60,11 +60,10 @@
         localBiblio: {
           "WOT-BINDING-REGISTRY": {
             title: "Web of Things (WoT) Binding Registry",
-            // href: "https://www.w3.org/TR/wot-binding-registry/",
-            href: "https://w3c.github.io/wot-binding-registry/",
+            href: "https://www.w3.org/TR/wot-binding-registry/",
             authors: ["Ege Korkan"],
             publisher: "W3C",
-            date: "TODO" //TODO: Add publication date
+            date: "November 2025"
           }
         }
       };

--- a/bindings/protocols/modbus/index.template.html
+++ b/bindings/protocols/modbus/index.template.html
@@ -60,11 +60,10 @@
         localBiblio: {
           "WOT-BINDING-REGISTRY": {
             title: "Web of Things (WoT) Binding Registry",
-            // href: "https://www.w3.org/TR/wot-binding-registry/",
-            href: "https://w3c.github.io/wot-binding-registry/",
+            href: "https://www.w3.org/TR/wot-binding-registry/",
             authors: ["Ege Korkan"],
             publisher: "W3C",
-            date: "TODO" //TODO: Add publication date
+            date: "November 2025"
           }
         }
       };

--- a/bindings/protocols/mqtt/index.html
+++ b/bindings/protocols/mqtt/index.html
@@ -77,11 +77,10 @@
           },
           "WOT-BINDING-REGISTRY": {
             title: "Web of Things (WoT) Binding Registry",
-            // href: "https://www.w3.org/TR/wot-binding-registry/",
-            href: "https://w3c.github.io/wot-binding-registry/",
+            href: "https://www.w3.org/TR/wot-binding-registry/",
             authors: ["Ege Korkan"],
             publisher: "W3C",
-            date: "TODO" //TODO: Add publication date
+            date: "November 2025"
           }
         }
       };
@@ -501,7 +500,7 @@
                 "subscribeevent",
                 "unsubscribeevent"
             ],
-            "mqv:filter": "thing1/events/overheating" 
+            "mqv:filter": "thing1/events/overheating"
         }
       </pre>
       <p>
@@ -514,7 +513,7 @@
             "href": "mqtt://broker.com:1883",
             "op": [
                 "invokeaction"
-            ], 
+            ],
             "mqv:topic": "application/devices/thing1/program/commands/reset"
         }
       </pre>
@@ -528,7 +527,7 @@
             "href": "mqtt://broker.com:1883",
             "op": [
                 "writeproperty"
-            ], 
+            ],
             "mqv:retain" : true,
             "mqv:topic": "application/devices/thing1/properties/test"
         },
@@ -554,7 +553,7 @@
                   "href": "mqtt://broker.com:1883",
                   "op": [
                       "observeallproperties"
-                  ], 
+                  ],
                   "mqv:filter": "application/devices/thing1/properties/#"
               }
       </pre>
@@ -568,8 +567,8 @@
                   "href": "mqtt://broker.com:1883",
                   "op": [
                       "writeproperty"
-                  ], 
-                  "mqv:qos": "1", 
+                  ],
+                  "mqv:qos": "1",
                   "mqv:retain" : true,
                   "mqv:topic": "application/devices/thing1/properties/test"
               },
@@ -578,8 +577,8 @@
                   "op": [
                       "readproperty",
                       "observeproperty"
-                  ], 
-                  "mqv:qos": "1", 
+                  ],
+                  "mqv:qos": "1",
                   "mqv:retain" : true,
                   "mqv:filter": "application/devices/thing1/properties/test"
               }]

--- a/bindings/protocols/mqtt/index.template.html
+++ b/bindings/protocols/mqtt/index.template.html
@@ -77,11 +77,10 @@
           },
           "WOT-BINDING-REGISTRY": {
             title: "Web of Things (WoT) Binding Registry",
-            // href: "https://www.w3.org/TR/wot-binding-registry/",
-            href: "https://w3c.github.io/wot-binding-registry/",
+            href: "https://www.w3.org/TR/wot-binding-registry/",
             authors: ["Ege Korkan"],
             publisher: "W3C",
-            date: "TODO" //TODO: Add publication date
+            date: "November 2025"
           }
         }
       };
@@ -304,7 +303,7 @@
                 "subscribeevent",
                 "unsubscribeevent"
             ],
-            "mqv:filter": "thing1/events/overheating" 
+            "mqv:filter": "thing1/events/overheating"
         }
       </pre>
       <p>
@@ -317,7 +316,7 @@
             "href": "mqtt://broker.com:1883",
             "op": [
                 "invokeaction"
-            ], 
+            ],
             "mqv:topic": "application/devices/thing1/program/commands/reset"
         }
       </pre>
@@ -331,7 +330,7 @@
             "href": "mqtt://broker.com:1883",
             "op": [
                 "writeproperty"
-            ], 
+            ],
             "mqv:retain" : true,
             "mqv:topic": "application/devices/thing1/properties/test"
         },
@@ -357,7 +356,7 @@
                   "href": "mqtt://broker.com:1883",
                   "op": [
                       "observeallproperties"
-                  ], 
+                  ],
                   "mqv:filter": "application/devices/thing1/properties/#"
               }
       </pre>
@@ -371,8 +370,8 @@
                   "href": "mqtt://broker.com:1883",
                   "op": [
                       "writeproperty"
-                  ], 
-                  "mqv:qos": "1", 
+                  ],
+                  "mqv:qos": "1",
                   "mqv:retain" : true,
                   "mqv:topic": "application/devices/thing1/properties/test"
               },
@@ -381,8 +380,8 @@
                   "op": [
                       "readproperty",
                       "observeproperty"
-                  ], 
-                  "mqv:qos": "1", 
+                  ],
+                  "mqv:qos": "1",
                   "mqv:retain" : true,
                   "mqv:filter": "application/devices/thing1/properties/test"
               }]

--- a/bindings/protocols/profinet/index.html
+++ b/bindings/protocols/profinet/index.html
@@ -42,6 +42,13 @@
             href: "https://profinetuniversity.com/",
             publisher: "PROFINET University",
             date: "2024"
+          },
+          "WOT-BINDING-REGISTRY": {
+            title: "Web of Things (WoT) Binding Registry",
+            href: "https://www.w3.org/TR/wot-binding-registry/",
+            authors: ["Ege Korkan"],
+            publisher: "W3C",
+            date: "November 2025"
           }
         },
         otherLinks: [
@@ -81,17 +88,7 @@
               }
             ]
           }
-        ],
-        localBiblio: {
-          "WOT-BINDING-REGISTRY": {
-            title: "Web of Things (WoT) Binding Registry",
-            //, href: "https://www.w3.org/TR/wot-binding-registry/"
-            href: "https://w3c.github.io/wot-binding-registry/",
-            authors: ["Ege Korkan"],
-            publisher: "W3C",
-            date: "TODO" //TODO: Add publication date
-          }
-        }
+        ]
       };
     </script>
     <title>Web of Things (WoT) PROFINET Binding</title>


### PR DESCRIPTION
simple update to all bindings' link to registry. Also in profinet, there were two `localBiblio` objects so that should reduce respec warnings.